### PR TITLE
Added RNA-seq reference information for yeast.

### DIFF
--- a/bcbio/rnaseq/dexseq.py
+++ b/bcbio/rnaseq/dexseq.py
@@ -46,6 +46,10 @@ def run_count(bam_file, dexseq_gff, stranded, out_file, data):
         logger.info("DEXseq is not installed, skipping exon-level counting.")
         return None
 
+    if dd.get_aligner(data) == "bwa":
+        logger.info("Can't use DEXSeq with bwa alignments, skipping exon-level counting.")
+        return None
+
     sort_flag = "name" if sort_order == "queryname" else "pos"
     is_paired = bam.is_paired(bam_file)
     paired_flag = "yes" if is_paired else "no"

--- a/config/genomes/sacCer3-resources.yaml
+++ b/config/genomes/sacCer3-resources.yaml
@@ -1,5 +1,14 @@
-version: 4
+version: 5
 
 aliases:
   ensembl: saccharomyces_cerevisiae
   snpeff: EF4.74
+
+rnaseq:
+  transcripts: ../rnaseq/ref-transcripts.gtf
+  transcripts_mask: ../rnaseq/ref-transcripts-mask.gtf
+  transcriptome_index:
+    tophat: ../rnaseq/tophat/sacCer3_transcriptome.ver
+  dexseq: ../rnaseq/ref-transcripts.dexseq.gff3
+  refflat: ../rnaseq/ref-transcripts.refFlat
+  rRNA_fa: ../rnaseq/rRNA.fa


### PR DESCRIPTION
I added RNA-seq annotations to the sacCer3 configuration file.  In my testing, yeast RNA-seq works, once the annotation files are manually generated with `cloudbiolinux/utils/prepare_tx_gff.py` and indices are built with `bcbio_nextgen.py upgrade`.  Alignment-only pipelines still work when the referenced RNA files aren't installed.