### PR TITLE
Disabled DEXSeq when the aligner is bwa.

### DIFF
--- a/bcbio/rnaseq/dexseq.py
+++ b/bcbio/rnaseq/dexseq.py
@@ -46,6 +46,10 @@ def run_count(bam_file, dexseq_gff, stranded, out_file, data):
         logger.info("DEXseq is not installed, skipping exon-level counting.")
         return None
 
+    if dd.get_aligner(data) == "bwa":
+        logger.info("Can't use DEXSeq with bwa alignments, skipping exon-level counting.")
+        return None
+
     sort_flag = "name" if sort_order == "queryname" else "pos"
     is_paired = bam.is_paired(bam_file)
     paired_flag = "yes" if is_paired else "no"


### PR DESCRIPTION
Newer versions of DEXSeq require the NH flag, which bwa doesn't set (see [here](http://seqanswers.com/forums/showthread.php?t=34990)).  This small workaround just turns off DEXSeq quantifications when bwa is the aligner so that the analysis doesn't crash.  This is probably a rare pipeline configuration (RNA-seq with bwa), but we do use it sometimes.