### PR TITLE
Added GATK command line option to ignore quality score problems.

### DIFF
--- a/bcbio/pipeline/qcsummary.py
+++ b/bcbio/pipeline/qcsummary.py
@@ -633,7 +633,8 @@ def _count_rRNA_reads(in_bam, out_file, ref_file, rRNA_interval, single_end, con
                       "-I", in_bam,
                       "-log", tx_out_file,
                       "-L", rRNA_coor,
-                      "--filter_reads_with_N_cigar"]
+                      "--filter_reads_with_N_cigar",
+                      "-allowPotentiallyMisencodedQuals"]
             jvm_opts = broad.get_gatk_framework_opts(config)
             cmd = [config_utils.get_program("gatk-framework", config)] + jvm_opts + params
             do.run(cmd, "counts rRNA for %s" % in_bam)


### PR DESCRIPTION
I ran into a minor problem where GATK was complaining about quality scores being out of bounds in certain input files.  This is in rRNA read counting in the QC steps.

I didn't dig into it too much, but it seems like GATK might be more restrictive about the spec than STAR or bwa (more [here](https://www.biostars.org/p/94637/) or [here](https://gatkforums.broadinstitute.org/discussion/2230/allow-potentially-misencoded-quality-scores-and-wrong-encoding-for-quality-scores-error)).  In this case my reads were Illumina 1.5, as verified by FastQC, and all other steps in the pipeline ran fine.  Strangely, only one out of three samples in the same run had this problem.

A quick workaround is to turn off this check for GATK, since it shouldn't matter too much here where it's just used to count reads.