### PR TITLE
Minor workaround to avoid crash when no variants are found.

### DIFF
--- a/bcbio/variation/effects.py
+++ b/bcbio/variation/effects.py
@@ -194,6 +194,8 @@ def snpeff_effects(vcf_in, data):
     """
     if vcfutils.vcf_has_variants(vcf_in):
         return _run_snpeff(vcf_in, "vcf", data)
+    else:
+        return None, None
 
 def _snpeff_args_from_config(data):
     """Retrieve snpEff arguments supplied through input configuration.


### PR DESCRIPTION
I ran into a problem running small test cases that didn't have enough reads to call variants, which crashed the pipeline at effects.py line 29:

    ann_vrn_file, stats_file = snpeff_effects(in_file, data)

`snp_effects` returns `None` in this case (`vcfutils.vcf_has_variants` returns `False`), which can't be unpacked to two variables.  This fix makes `snpeff_effects` always return a tuple.