### PR TITLE
Add support for Azure Blob storage service

### DIFF
--- a/bcbio/distributed/objectstore.py
+++ b/bcbio/distributed/objectstore.py
@@ -1,5 +1,10 @@
-"""Manage pushing and pulling files from an object store like Amazon Web Services S3.
 """
+Manage pushing and pulling files from an object store like
+Amazon Web Services S3.
+"""
+# pylint: disable=redefined-builtin
+
+import abc
 import collections
 import os
 import subprocess
@@ -7,236 +12,436 @@ import sys
 import zlib
 
 import boto
+import six
 
 from bcbio.distributed.transaction import file_transaction
 from bcbio import utils
-
-# ## definitions
 
 SUPPORTED_REMOTES = ("s3://",)
 BIODATA_INFO = {"s3": "s3://biodata/prepped/{build}/{build}-{target}.tar.gz"}
 REGIONS_NEWPERMS = {"s3": ["eu-central-1"]}
 
-# ## Utilities
 
-def is_remote(fname):
-    return isinstance(fname, basestring) and fname.lower().startswith(SUPPORTED_REMOTES)
+@six.add_metaclass(abc.ABCMeta)
+class FileHandle(object):
 
-def file_exists_or_remote(fname):
-    """Check if a file exists or is accessible remotely.
-    """
-    if is_remote(fname):
-        return True
-    else:
-        return utils.file_exists(fname)
+    """Contract class for the file handle."""
 
-def parse_remote(fname):
-    """Parses a remote filename into bucket and key information.
+    def __init__(self):
+        self._iter = self._line_iter()
 
-    Handles S3 with optional region name specified in key:
-      BUCKETNAME@REGIONNAME/KEY
-    """
-    RemoteFile = collections.namedtuple("RemoteFile", "store,bucket,key,region")
-    if fname.startswith("s3://"):
-        parts = fname.split("//")[-1].split("/", 1)
+    def __enter__(self):
+        """Define what the context manager should do at the beginning
+        of the block created by the with statement.
+        """
+        return self
+
+    def __exit__(self, *args):
+        """Define what the context manager should do after its block
+        has been executed (or terminates).
+        """
+        self.close()
+
+    def __iter__(self):
+        """Return the iterator for the current file."""
+        return self
+
+    def _line_iter(self):
+        """Storage manager file iterator splits by buffer size instead
+        of by newline. This wrapper puts them back into lines.
+
+        From mrjob: https://github.com/Yelp/mrjob/blob/master/mrjob/util.py
+        """
+        buf = ""
+        search_offset = 0
+        for chunk in self._chunk_iter():
+            buf += chunk
+            start = 0
+            while True:
+                end = buf.find("\n", start + search_offset) + 1
+                if end:  # if find() returned -1, end would be 0
+                    yield buf[start:end]
+                    start = end
+                    # reset the search offset
+                    search_offset = 0
+                else:
+                    # this will happen eventually
+                    buf = buf[start:]
+                    # set search offset so we do not need to scan this part
+                    # of the buffer again
+                    search_offset = len(buf)
+                    break
+        if buf:
+            yield buf + '\n'
+
+    @abc.abstractmethod
+    def _chunk_iter(self):
+        """Chunk iterator over the received file."""
+        pass
+
+    @abc.abstractmethod
+    def read(self, size):
+        """Read at most size bytes from the file (less if the read hits EOF
+        before obtaining size bytes).
+        """
+        pass
+
+    @abc.abstractmethod
+    def next(self):
+        """Return the next item from the container."""
+        pass
+
+    @abc.abstractmethod
+    def close(self):
+        """Close the file handle."""
+        pass
+
+
+class S3Handle(FileHandle):
+
+    """File object for the Amazon S3 files."""
+
+    def __init__(self, key):
+        super(S3Handle, self).__init__(key)
+        self._key = key
+        if self._key.name.endswith(".gz"):
+            decompress = zlib.decompressobj(16 | zlib.MAX_WBITS)
+            self._decompress = decompress.decompress
+        else:
+            self._decompress = lambda value: value
+
+    def _chunk_iter(self):
+        """Iterator over the S3 file."""
+        for chunk in self._key:
+            yield self._decompress(chunk)
+
+    def read(self, size):
+        """Read at most size bytes from the file (less if the read hits EOF
+        before obtaining size bytes).
+        """
+        return self._key.read(size)
+
+    def next(self):
+        """Return the next item from the container."""
+        return self._iter.next()
+
+    def close(self):
+        """Close the file handle."""
+        self._key.close(fast=True)
+
+
+@six.add_metaclass(abc.ABCMeta)
+class StorageManager(object):
+
+    """The contract class for all the storage managers."""
+
+    @abc.abstractmethod
+    def check_resource(self, resource):
+        """Check if the received resource can be processed by
+        the current storage manager.
+        """
+        pass
+
+    @abc.abstractmethod
+    def parse_remote(self, filename):
+        """Parse a remote filename in order to obtain information
+        related to received resource.
+        """
+        pass
+
+    @abc.abstractmethod
+    def connect(self, resource):
+        """Return a connection object pointing to the endpoint
+        associated to the received resource.
+        """
+        pass
+
+    @abc.abstractmethod
+    def download(self, filename, input_dir, dl_dir=None):
+        """Download the resource from the storage."""
+        pass
+
+    @abc.abstractmethod
+    def list(self, path):
+        """Return a list containing the names of the entries in the directory
+        given by path. The list is in arbitrary order.
+        """
+        pass
+
+    @abc.abstractmethod
+    def open(self, filename):
+        """Provide a handle-like object for streaming."""
+        pass
+
+
+class AmazonS3(StorageManager):
+
+    """Amazon Simple Storage Service (Amazon S3) Manager."""
+
+    _DEFAULT_REGION = "us-east-1"
+    _REMOTE_FILE = collections.namedtuple(
+        "RemoteFile", ["store", "bucket", "key", "region"])
+    _S3_FILE = "s3://%(bucket)s%(region)s/%(key)s"
+
+    def __init__(self):
+        super(AmazonS3, self).__init__()
+
+    @classmethod
+    def parse_remote(cls, filename):
+        """Parses a remote filename into bucket and key information.
+
+        Handles S3 with optional region name specified in key:
+            BUCKETNAME@REGIONNAME/KEY
+        """
+        parts = filename.split("//")[-1].split("/", 1)
         bucket, key = parts if len(parts) == 2 else (parts[0], None)
         if bucket.find("@") > 0:
             bucket, region = bucket.split("@")
         else:
             region = None
-        return RemoteFile("s3", bucket, key, region)
-    else:
-        raise NotImplementedError("Unexpected object store %s" % fname)
 
-# ## Establish connection
+        return cls._REMOTE_FILE("s3", bucket, key, region)
 
-def connect(fname):
-    if fname.startswith("s3://"):
-        return _connect_s3(fname)
-    else:
-        raise NotImplementedError("Unexpected object store %s" % fname)
+    @classmethod
+    def _cl_aws_cli(cls, file_info, region):
+        """Command line required for download using the standard AWS
+        command line interface.
+        """
+        s3file = cls._S3_FILE % {"bucket": file_info.bucket,
+                                 "key": file_info.key,
+                                 "region": ""}
+        command = [os.path.join(os.path.dirname(sys.executable), "aws"),
+                   "s3", "cp", "--region", region, s3file]
+        return (command, "awscli")
 
-def _connect_s3(fname=None):
-    return boto.s3.connect_to_region(_get_region_s3(fname))
+    @staticmethod
+    def _cl_gof3r(file_info, region):
+        """Command line required for download using gof3r."""
+        command = ["gof3r", "get", "--no-md5",
+                   "-k", file_info.key,
+                   "-b", file_info.bucket,
+                   "--endpoint=s3-%s.amazonaws.com" % region]
+        return (command, "gof3r")
 
-# ## Get region for object stores with multi-region support
+    @classmethod
+    def _download_cl(cls, filename):
+        """Provide potentially streaming download from S3 using gof3r
+        or the AWS CLI.
 
-def _get_region_s3(fname=None):
-    """Retrieve region from standard environmental variables or file name.
+        Selects the correct endpoint for non us-east support:
+            http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
 
-    http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-environment
-    """
-    if fname:
-        r_fname = parse_remote(fname)
-        if r_fname.region:
-            return r_fname.region
-    return os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
+        In eu-central-1 gof3r does not support new AWS signatures,
+        so we fall back to the standard AWS commandline interface:
+            https://github.com/rlmcpherson/s3gof3r/issues/45
+        """
+        file_info = cls.parse_remote(filename)
+        region = cls.get_region(filename)
+        if region != "us-east-1":
+            if region in REGIONS_NEWPERMS["s3"]:
+                return cls._cl_aws_cli(file_info, region)
 
-def default_region(fname):
-    if fname.startswith("s3://"):
-        return _get_region_s3()
-    else:
-        raise NotImplementedError("Unexpected object store %s" % fname)
+        return cls._cl_gof3r(file_info, region)
 
-# ## Retrieve files
+    @classmethod
+    def get_region(cls, resource=None):
+        """Retrieve region from standard environmental variables
+        or file name.
 
-def _s3_download_cl(fname):
-    """Provide potentially streaming download from S3 using gof3r or the AWS CLI.
+        More information of the following link: http://goo.gl/Vb9Jky
+        """
+        if resource:
+            resource_info = cls.parse_remote(resource)
+            if resource_info.region:
+                return resource_info.region
 
-    Selects the correct endpoint for non us-east support:
-    http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
+        return os.environ.get("AWS_DEFAULT_REGION", cls._DEFAULT_REGION)
 
-    In eu-central-1 gof3r does not support new AWS signatures, so we fall back
-    to the standard AWS commandline interface:
+    @classmethod
+    def check_resource(cls, resource):
+        """Check if the received resource can be processed by
+        the current storage manager.
+        """
+        if resource and resource.startswith("s3://"):
+            return True
 
-    https://github.com/rlmcpherson/s3gof3r/issues/45
-    """
-    r_fname = parse_remote(fname)
-    cmd = ["gof3r", "get", "--no-md5", "-k", r_fname.key, "-b", r_fname.bucket]
-    region = _get_region_s3(fname)
-    if region != "us-east-1":
-        if region in REGIONS_NEWPERMS["s3"]:
-            return _s3_download_cl_aws_cli(fname)
-        cmd.append("--endpoint=s3-%s.amazonaws.com" % region)
-    return cmd, "gof3r"
+        return False
 
-def _s3_download_cl_aws_cli(fname):
-    """Potentially streaming download via the standard AWS command line interface.
-    """
-    r_fname = parse_remote(fname)
-    region = _get_region_s3(fname)
-    s3file = "s3://%s/%s" % (r_fname.bucket, r_fname.key)
-    region = _get_region_s3(fname)
-    cmd = [os.path.join(os.path.dirname(sys.executable), "aws"), "s3", "cp", "--region", region, s3file]
-    return cmd, "awscli"
+    @classmethod
+    def connect(cls, resource):
+        """Connect to this Region's endpoint.
 
-def download(fname, input_dir, dl_dir=None):
-    if fname.startswith("s3://"):
-        r_fname = parse_remote(fname)
+        Returns a connection object pointing to the endpoint associated
+        to the received resource.
+        """
+        return boto.s3.connect_to_region(cls.get_region(resource))
+
+    @classmethod
+    def download(cls, filename, input_dir, dl_dir=None):
+        """Provide potentially streaming download from S3 using gof3r
+        or the AWS CLI.
+        """
+        file_info = cls.parse_remote(filename)
         if not dl_dir:
-            dl_dir = utils.safe_makedir(os.path.join(input_dir, r_fname.bucket, os.path.dirname(r_fname.key)))
-        out_file = os.path.join(dl_dir, os.path.basename(r_fname.key))
+            dl_dir = os.path.join(input_dir, file_info.bucket,
+                                  os.path.dirname(file_info.key))
+            utils.safe_makedir(dl_dir)
+
+        out_file = os.path.join(dl_dir, os.path.basename(file_info.key))
+
         if not utils.file_exists(out_file):
             with file_transaction({}, out_file) as tx_out_file:
-                cmd, prog = _s3_download_cl(fname)
+                command, prog = cls._download_cl(filename)
                 if prog == "gof3r":
-                    cmd += ["-p", tx_out_file]
+                    command.extend(["-p", tx_out_file])
                 elif prog == "awscli":
-                    cmd += [tx_out_file]
+                    command.extend([tx_out_file])
                 else:
-                    raise NotImplementedError("Unexpected download program %s" % prog)
-                subprocess.check_call(cmd)
+                    raise NotImplementedError(
+                        "Unexpected download program %s" % prog)
+                subprocess.check_call(command)
         return out_file
-    elif not fname or os.path.exists(fname):
-        return fname
+
+    @classmethod
+    def cl_input(cls, filename, unpack=True, anonpipe=True):
+        """Return command line input for a file, handling streaming
+        remote cases.
+        """
+        command, prog = cls._download_cl(filename)
+        if prog == "awscli":
+            command.append("-")
+
+        command = " ".join(command)
+        if filename.endswith(".gz") and unpack:
+            command = "%(command)s | gunzip -c" % {"command": command}
+        if anonpipe:
+            command = "<(%(command)s)" % {"command": command}
+
+        return command
+
+    @classmethod
+    def list(cls, path):
+        """Return a list containing the names of the entries in the directory
+        given by path. The list is in arbitrary order.
+        """
+        file_info = cls.parse_remote(path)
+        connection = cls.connect(path)
+        bucket = connection.get_bucket(file_info.bucket)
+        region = "@%s" % file_info.region if file_info.region else ""
+
+        output = []
+        for key in bucket.get_all_keys(prefix=file_info.key):
+            output.append(cls._S3_FILE % {"bucket": file_info.bucket,
+                                          "key": key.name,
+                                          "region": region})
+        return output
+
+    @classmethod
+    def open(cls, filename):
+        """Return a handle like object for streaming from S3."""
+        file_info = cls.parse_remote(filename)
+        connection = cls.connect(filename)
+        try:
+            s3_bucket = connection.get_bucket(file_info.bucket)
+        except boto.exception.S3ResponseError as error:
+            # if we don't have bucket permissions but folder permissions,
+            # try without validation
+            if error.status == 403:
+                s3_bucket = connection.get_bucket(file_info.bucket,
+                                                  validate=False)
+            else:
+                raise
+
+        s3_key = s3_bucket.get_key(file_info.key)
+        return S3Handle(s3_key)
+
+
+def _get_storage_manager(resource):
+    """Return a storage manager which can process this resource."""
+    for manager in (AmazonS3, ):
+        if manager.check_resource(resource):
+            return manager()
+
+    raise NotImplementedError("Unexpected object store  %(resource)s" %
+                              {"resource": resource})
+
+
+def is_remote(fname):
+    """Check if the received file is recognised by one of
+    the available storage managers.
+    """
+    try:
+        _get_storage_manager(fname)
+    except ValueError:
+        return False
+
+    return True
+
+
+def file_exists_or_remote(fname):
+    """Check if a file exists or is accessible remotely."""
+    if is_remote(fname):
+        return True
     else:
-        raise NotImplementedError("Unexpected object store %s" % fname)
+        return utils.file_exists(fname)
+
+
+def default_region(fname):
+    """Return the default region for the received resource.
+
+    Note:
+        This feature is available only for AmazonS3 storage manager.
+    """
+    manager = _get_storage_manager(fname)
+    if hasattr(manager, "get_region"):
+        return manager.get_region()
+
+    raise NotImplementedError("Unexpected object store %s" % fname)
+
+
+def connect(filename):
+    """Returns a connection object pointing to the endpoint associated
+    to the received resource.
+    """
+    manager = _get_storage_manager(filename)
+    return manager.connect(filename)
+
+
+def download(fname, input_dir, dl_dir=None):
+    """Download the resource from the storage."""
+    manager = _get_storage_manager(fname)
+    return manager.download(fname, input_dir, dl_dir)
+
 
 def cl_input(fname, unpack=True, anonpipe=True):
-    """Return command line input for a file, handling streaming remote cases.
+    """Return command line input for a file, handling streaming
+    remote cases.
     """
-    if not fname:
-        return fname
-    elif fname.startswith("s3://"):
-        cmd, prog = _s3_download_cl(fname)
-        if prog == "awscli":
-            cmd += ["-"]
-        cmd = " ".join(cmd)
-        if fname.endswith(".gz") and unpack:
-            cmd += " | gunzip -c"
-        if anonpipe:
-            cmd = "<(" + cmd + ")"
-        return cmd
-    else:
+    try:
+        manager = _get_storage_manager(fname)
+    except ValueError:
         return fname
 
-# ## List buckets
+    return manager.cl_input(fname, unpack, anonpipe)
+
 
 def list(remote_dirname):
-    if remote_dirname.startswith("s3://"):
-        return _s3_list(remote_dirname)
-    else:
-        raise NotImplementedError("Unexpected object store %s" % remote_dirname)
+    """Return a list containing the names of the entries in the directory
+    given by path. The list is in arbitrary order.
+    """
+    manager = _get_storage_manager(remote_dirname)
+    return manager.list(remote_dirname)
 
-def _s3_list(remote_dirname):
-    r_fname = parse_remote(remote_dirname)
-    conn = connect(remote_dirname)
-    bucket = conn.get_bucket(r_fname.bucket)
-    out = []
-    region = "@%s" % r_fname.region if r_fname.region else ""
-    for key in bucket.get_all_keys(prefix=r_fname.key):
-        out.append("s3://%s%s/%s" % (r_fname.bucket, region, key.name))
-    return out
-
-# ## File handles
 
 def open(fname):
-    """Provide a handle-like object for streaming
-    """
-    if fname.startswith("s3://"):
-        return _s3_handle(fname)
-    else:
-        raise NotImplementedError("Unexpected object store %s" % fname)
+    """Provide a handle-like object for streaming."""
+    manager = _get_storage_manager(fname)
+    return manager.open(fname)
 
-def _s3_handle(fname):
-    """Return a handle like object for streaming from S3.
-    """
-    class S3Handle:
-        def __init__(self, key):
-            self._key = key
-            self._iter = self._line_iter()
-        def _line_iter(self):
-            """From mrjob: https://github.com/Yelp/mrjob/blob/master/mrjob/util.py
-            """
-            buf = ""
-            search_offset = 0
-            for chunk in self._chunk_iter():
-                buf += chunk
-                start = 0
-                while True:
-                    end = buf.find("\n", start + search_offset) + 1
-                    if end:  # if find() returned -1, end would be 0
-                        yield buf[start:end]
-                        start = end
-                        # reset the search offset
-                        search_offset = 0
-                    else:
-                        # this will happen eventually
-                        buf = buf[start:]
-                        # set search offset so we do not need to scan this part of the buffer again
-                        search_offset = len(buf)
-                        break
-            if buf:
-                yield buf + '\n'
-        def _chunk_iter(self):
-            dec = zlib.decompressobj(16 | zlib.MAX_WBITS) if self._key.name.endswith(".gz") else None
-            for chunk in self._key:
-                if dec:
-                    chunk = dec.decompress(chunk)
-                if chunk:
-                    yield chunk
-        def __enter__(self):
-            return self
-        def __exit__(self, *args):
-            self.close()
-        def __iter__(self):
-            return self
-        def read(self, size):
-            return self._key.read(size)
-        def next(self):
-            return self._iter.next()
-        def close(self):
-            self._key.close(fast=True)
 
-    r_fname = parse_remote(fname)
-    s3 = connect(fname)
-    try:
-        s3b = s3.get_bucket(r_fname.bucket)
-    except boto.exception.S3ResponseError, e:
-        # if we don't have bucket permissions but folder permissions, try without validation
-        if e.status == 403:
-            s3b = s3.get_bucket(r_fname.bucket, validate=False)
-        else:
-            raise
-    s3key = s3b.get_key(r_fname.key)
-    return S3Handle(s3key)
+def parse_remote(fname):
+    """Parses a remote filename in order to obtain information
+    related to received resource.
+    """
+    manager = _get_storage_manager(fname)
+    return manager.parse_remote(fname)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+azure
 biopython>=1.61
 boto>=2.34.0
 Cython>=0.19


### PR DESCRIPTION
I have refactored the ```bcbio.distributed.objectstore``` in order to ease the future adding of one storage service.
For each storage service will be required one ```StorageManager``` and one ```FileHandle```.

The ```StorageManager``` is an interface which can ease the interaction with the storage service and is  exposing the following methods:
```

    def check_resource(self, resource):
        """Check if the received resource can be processed by
        the current storage manager.
        """
        pass

    def parse_remote(self, filename):
        """Parse a remote filename in order to obtain information
        related to received resource.
        """
        pass

    def connect(self, resource):
        """Return a connection object pointing to the endpoint
        associated to the received resource.
        """
        pass

    def download(self, filename, input_dir, dl_dir=None):
        """Download the resource from the storage."""
        pass

    def list(self, path):
        """Return a list containing the names of the entries in the directory
        given by path. The list is in arbitrary order.
        """
        pass

    def open(self, filename):
        """Provide a handle-like object for streaming."""
        pass
```

And the ```FileHandle``` is a handle-like object which facilitates interaction with the remote file.

This patch contains the ```StorageManager``` and the ```FileHandle``` for:
 - Amazon Simple Storage Service (Amazon S3)
 -  Azure Blob storage service

Thanks,
Alex