### PR TITLE
Show batch name when paired batch misses paired samples (VarScan)

### DIFF
--- a/bcbio/variation/varscan.py
+++ b/bcbio/variation/varscan.py
@@ -75,7 +75,10 @@ def _varscan_paired(align_bams, ref_file, items, target_regions, out_file):
 
     paired = get_paired_bams(align_bams, items)
     if not paired.normal_bam:
-        raise ValueError("Require both tumor and normal BAM files for VarScan cancer calling")
+        affected_batch = items[0]["metadata"]["batch"]
+        message = ("Batch {} requires both tumor and normal BAM files for"
+            " VarScan cancer calling").format(affected_batch)
+        raise ValueError(message)
 
     if not file_exists(out_file):
         orig_out_file = out_file


### PR DESCRIPTION
With large data sets, errors in batches (missing tumor/normal
phenotypes) can be confusing as it's hard to find the culprit. This
commit adds the batch name to the message printed, so it's easier to
spot errors.