### PR TITLE
Remove obsolete -I flag from bwa aln (handled by seqtk now).

### DIFF
--- a/bcbio/ngsalign/bwa.py
+++ b/bcbio/ngsalign/bwa.py
@@ -174,9 +174,7 @@ def _align_backtrack(fastq_file, pair_file, ref_file, out_file, names, rg_info, 
 def _bwa_args_from_config(config):
     num_cores = config["algorithm"].get("num_cores", 1)
     core_flags = ["-t", str(num_cores)] if num_cores > 1 else []
-    qual_format = config["algorithm"].get("quality_format", "").lower()
-    qual_flags = ["-I"] if qual_format == "illumina" else []
-    return core_flags + qual_flags
+    return core_flags
 
 def _run_bwa_align(fastq_file, ref_file, out_file, config):
     aln_cl = [config_utils.get_program("bwa", config), "aln",


### PR DESCRIPTION
I was encountering strange errors in bwa when aligning shorter reads in Illumina 1.5 FASTQ format.  I tracked it down to bwa backtrack (`aln` + `samse` / `sampe`) and the fact that (as far as I can tell) it tries to convert the FASTQ quality scores twice.  The first time is the `-I` flag to `bwa aln`, and the second is with `seqtk -V` in `fastq_convert_pipe_cl` (in `alignprep.py`).  I'm not sure how the quality scores are encoded in the intermediate `.sai` files, but I observed that giving `bwa aln` an Illumina 1.5 file with `-I` and the subsequent `bwa samse` command an Illumina 1.9 file (the effect of the seqtk pipe, which converts based on input format) crashed bwa or gave invalid bams.

For reference, the error messages included "SEQ and QUAL are of different length" from bwa, "Invalid alignment: Quality string contains invalid quality value" from libmaus, and "Cannot encode phred score" from fastqc, depending on the input data.

Taking out the `-I` flag to `bwa aln` fixes the problem and yields correct bams (Sanger / Illumina 1.9 format from both standard and illumina input formats).  I thought that was a lighter-weight solution than changing / complicating the seqtk logic, which is used by more paths through the pipeline.