### PR TITLE
[FIX] Bug in getting Docker work_dir

### DIFF
--- a/bcbio/pipeline/run_info.py
+++ b/bcbio/pipeline/run_info.py
@@ -84,7 +84,7 @@ def setup_directories(work_dir, fc_dir, config, config_file):
                                                         config, config_file)
     # check default install for tool data if not found locally
     if not os.path.exists(os.path.join(galaxy_dir, "tool-data")):
-        _, config_file = config_utils.load_system_config()
+        _, config_file = config_utils.load_system_config(work_dir=work_dir)
         if os.path.exists(os.path.join(os.path.dirname(config_file), "tool-data")):
             galaxy_dir = os.path.dirname(config_file)
     return {"fastq": fastq_dir, "galaxy": galaxy_dir,


### PR DESCRIPTION
I got the following error after a fresh Docker installation, despite having specified the **--workdir** parameter. The proposed change fixed the issue.

Error log:

```python
Traceback (most recent call last):
  File "/usr/local/bin/bcbio_nextgen.py", line 226, in <module>
    main(**kwargs)
  File "/usr/local/bin/bcbio_nextgen.py", line 43, in main
    run_main(**kwargs)
  File "/usr/local/share/bcbio-nextgen/anaconda/lib/python2.7/site-packages/bcbio/pipeline/main.py", line 37, in run_main
    fc_dir, run_info_yaml)
  File "/usr/local/share/bcbio-nextgen/anaconda/lib/python2.7/site-packages/bcbio/pipeline/main.py", line 73, in _run_toplevel
    dirs = run_info.setup_directories(work_dir, fc_dir, config, config_file)
  File "/usr/local/share/bcbio-nextgen/anaconda/lib/python2.7/site-packages/bcbio/pipeline/run_info.py", line 87, in setup_directories
    _, config_file = config_utils.load_system_config()
  File "/usr/local/share/bcbio-nextgen/anaconda/lib/python2.7/site-packages/bcbio/pipeline/config_utils.py", line 67, in load_system_config
    assert work_dir is not None, "Need working directory to merge docker config"
AssertionError: Need working directory to merge docker config
Exception in thread Thread-1 (most likely raised during interpreter shutdown):
```
