### PR TITLE
Fix package name for OpenSSL library/headers on Red Hat systems

### DIFF
--- a/docs/contents/installation.rst
+++ b/docs/contents/installation.rst
@@ -94,7 +94,7 @@ This requires the following additional system requirements to be in place:
   ``perl perl-devel perl-core``)
 - bzip2 (with development libraries)
 - curl (with development libraries; On Ubuntu: ``libcurl4-openssl-dev``, On
-  RedHat: ``libcurl4-openssl-dev``)
+  RedHat: ``openssl-devel``)
 - XML development libraries (On Ubuntu: ``libxml2-dev``, on RedHat: ``libxml2-devel``)
 - curses with development libraries (On Ubuntu: ``libncurses5-dev``, on RedHat ``ncurses-devel``)
 


### PR DESCRIPTION
This fixes the package name needed to ensure the OpenSSL library and headers are installed on Red Hat systems. 