### PR TITLE
Add logfile and timestamp timeframe limit when processing/pulling collectl raw files

### DIFF
--- a/bcbio/graph/collectl.py
+++ b/bcbio/graph/collectl.py
@@ -182,7 +182,6 @@ def load_collectl(pattern, start_time, end_time):
     cols = []
     rows = []
 
-    # XXX: prefilter here those rawfiles that need to be processed
     for path in glob.glob(pattern):
         hardware, raw = _parse_raw(
             _CollectlGunzip(path, 'r'), start_tstamp, end_tstamp)

--- a/bcbio/graph/collectl.py
+++ b/bcbio/graph/collectl.py
@@ -181,6 +181,8 @@ def load_collectl(pattern, start_time, end_time):
 
     cols = []
     rows = []
+
+    # XXX: prefilter here those rawfiles that need to be processed
     for path in glob.glob(pattern):
         hardware, raw = _parse_raw(
             _CollectlGunzip(path, 'r'), start_tstamp, end_tstamp)

--- a/bcbio/graph/graph.py
+++ b/bcbio/graph/graph.py
@@ -15,7 +15,6 @@ import pandas as pd
 
 from bcbio import utils
 from bcbio.graph.collectl import load_collectl
-# from bcbiovm.graph.elasticluster import fetch_collectl
 
 
 def get_bcbio_nodes(path):
@@ -28,7 +27,7 @@ def get_bcbio_nodes(path):
     with open(path, 'r') as file_handle:
         hosts = collections.defaultdict(dict)
         for line in file_handle:
-            matches = re.search(r'\] ([^:]):', line)
+            matches = re.search(r'\]\s([^:]+):', line)
             if not matches:
                 continue
 

--- a/bcbio/graph/graph.py
+++ b/bcbio/graph/graph.py
@@ -106,7 +106,9 @@ def calc_deltas(data_frame, series=None):
 
 def remove_outliers(series, stddev):
     """Remove the outliers from a series."""
-    return series[(series - series.mean()).abs() < stddev * series.std()]
+    #XXX: cannot reindex from duplicate axis
+    series_nodup = series.drop_duplicates(take_last=True)
+    return series_nodup[(series_nodup - series_nodup.mean()).abs() < stddev * series_nodup.std()]
 
 
 def prep_for_graph(data_frame, series=None, delta_series=None, smoothing=None,
@@ -263,7 +265,7 @@ def _time_frame(bcbio_log):
     return output(min(bcbio_timings), max(bcbio_timings), bcbio_timings)
 
 
-def resource_usage(bcbio_log, rawdir, verbose):
+def resource_usage(bcbio_log, cluster, rawdir, verbose):
     """Generate system statistics from bcbio runs.
 
     Parse the obtained files and put the information in
@@ -297,7 +299,7 @@ def resource_usage(bcbio_log, rawdir, verbose):
 
         host = re.sub(r'-\d{8}-\d{6}\.raw\.gz$', '', collectl_file)
         hardware_info[host] = hardware
-        if "local" in args.cluster:
+        if "local" in cluster:
             nodes = get_bcbio_nodes(bcbio_log)
             for host in nodes:
                 hardware_info[host] = hardware

--- a/bcbio/graph/graph.py
+++ b/bcbio/graph/graph.py
@@ -108,9 +108,6 @@ def calc_deltas(data_frame, series=None):
 def remove_outliers(series, stddev):
     """Remove the outliers from a series."""
     #XXX: cannot reindex from duplicate axis
-
-    print("SERIES: ")
-    print(series)
     series_nodup = series.drop_duplicates(take_last=True)
     return series_nodup[(series_nodup - series_nodup.mean()).abs() < stddev * series_nodup.std()]
 
@@ -258,7 +255,7 @@ def graph_disk_io(data_frame, steps, disks):
     return plot
 
 
-def _time_frame(bcbio_log):
+def log_time_frame(bcbio_log):
     """The bcbio running time frame.
 
     :return:    an instance of :class collections.namedtuple:
@@ -288,22 +285,19 @@ def resource_usage(bcbio_log, cluster, rawdir, verbose):
     """
     data_frames = {}
     hardware_info = {}
-    time_frame = _time_frame(bcbio_log)
+    time_frame = log_time_frame(bcbio_log)
 
     for collectl_file in sorted(os.listdir(rawdir)):
         if not collectl_file.endswith('.raw.gz'):
             continue
 
-        # only load filenames within sampling timerange (gathered from bcbio_log time_frame)
+        # Only load filenames within sampling timerange (gathered from bcbio_log time_frame)
         matches = re.search(r'-(\d{8})-', collectl_file)
         if matches:
             ftime = datetime.strptime(matches.group(1), "%Y%m%d")
             ftime = pytz.utc.localize(ftime)
 
-        print("{} {} {}".format(time_frame[0], ftime, time_frame[1]))
-
         if ftime >= time_frame[0] and ftime <= time_frame[1]:
-
             collectl_path = os.path.join(rawdir, collectl_file)
             data, hardware = load_collectl(
                 collectl_path, time_frame.start, time_frame.end)
@@ -314,10 +308,6 @@ def resource_usage(bcbio_log, cluster, rawdir, verbose):
 
             host = re.sub(r'-\d{8}-\d{6}\.raw\.gz$', '', collectl_file)
             hardware_info[host] = hardware
-            if "local" in cluster:
-                nodes = get_bcbio_nodes(bcbio_log)
-                for host in nodes:
-                    hardware_info[host] = hardware
             if host not in data_frames:
                 data_frames[host] = data
             else:

--- a/docs/contents/cloud.rst
+++ b/docs/contents/cloud.rst
@@ -253,10 +253,10 @@ usage graphs with::
 
     bcbio_vm.py graph bcbio-nextgen.log
 
-Collectl stats will be in ``monitoring/collectl`` and plots are in
-``monitoring/graphs``. If you need to re-run plots later after shutting the
-cluster down, you can use the local collectl stats instead of retrieving from
-the server by running ``bcbio_vm.py graph bcbio-nextgen.log --cluster none``.
+By default the collectl stats will be in ``monitoring/collectl`` and plots in
+``monitoring/graphs`` based on the above log timeframe. If you need to re-run 
+plots later after shutting the cluster down, you can use the `none` cluster flag 
+by running ``bcbio_vm.py graph bcbio-nextgen.log --cluster none``.
 
 If you'd like to run graphing from a local non-AWS run, such as a local HPC cluster,
 run ``bcbio_vm.py graph bcbio-nextgen.log --cluster local`` instead.

--- a/docs/contents/cloud.rst
+++ b/docs/contents/cloud.rst
@@ -257,8 +257,10 @@ Collectl stats will be in ``monitoring/collectl`` and plots are in
 ``monitoring/graphs``. If you need to re-run plots later after shutting the
 cluster down, you can use the local collectl stats instead of retrieving from
 the server by running ``bcbio_vm.py graph bcbio-nextgen.log --cluster none``.
-If you'd like to run graphing from a local non-AWS run, manually place collectl
-files from each node to analyze in ``monitoring/collectl/yournodename-timestamp.raw.gz``.
+
+If you'd like to run graphing from a local non-AWS run, such as a local HPC cluster,
+run ``bcbio_vm.py graph bcbio-nextgen.log --cluster local`` instead.
+
 In addition to plots, the
 `summarize_timing.py <https://github.com/chapmanb/bcbio-nextgen/blob/master/scripts/utils/summarize_timing.py>`_
 utility script prepares a summary table of run times per step.


### PR DESCRIPTION
Now by default it pulls collectl files that fall within the range of the logfile. Otherwise it fetches an unnecessary amount of collectl rawfiles (GBs).