### PR TITLE
Add .travis.yml file for travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+sudo: required
+
+language: python
+
+services:
+  - docker
+
+env:
+  - BCBIO_DOCKER_PRIVILEGED=True
+
+before_install:
+  # Temporal fix for networking problem: https://github.com/travis-ci/travis-ci/issues/1484
+  - echo "127.0.0.1 "`hostname` | sudo tee /etc/hosts
+  # Get and install anaconda for custom Python installation
+  - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh
+  - bash Miniconda-latest-Linux-x86_64.sh -b -p ~/install/bcbio-vm/anaconda
+
+install:
+  # Install bcbio-nextgen and bcbio-nextgen-vm
+  - export PATH=~/install/bcbio-vm/anaconda/bin/:$PATH
+  - conda install --yes -c bcbio bcbio-nextgen-vm -q
+  # Get docker container
+  - bcbio_vm.py --datadir=${TRAVIS_BUILD_DIR}/tests/data install --tools
+
+script:
+  - cd tests && bash run_tests.sh docker
+
+notifications:
+    email: false

--- a/tests/test_automated_analysis.py
+++ b/tests/test_automated_analysis.py
@@ -372,7 +372,9 @@ class AutomatedAnalysisTest(unittest.TestCase):
         """
         self._install_test_files(self.data_dir)
         with make_workdir() as workdir:
-            cl = ["bcbio_vm.py", "ipython",
+            cl = ["bcbio_vm.py",
+                  "--datadir=%s" % self.data_dir,
+                  "ipython",
                   "--systemconfig=%s" % get_post_process_yaml(self.data_dir, workdir),
                   "--fcdir=%s" % os.path.join(self.data_dir, os.pardir, "100326_FC6107FAAXX"),
                   os.path.join(self.data_dir, "run_info-bam.yaml"),


### PR DESCRIPTION
This file tells Travis how to install and configure the pipeline, as well as how to run the tests.

Note though that the sole addition of this file is not enough, its also needed to:

1. Activate Travis for this repository in GitHub going to the repository settings in GitHub, Webhooks and Services, and activate Travis-CI
2. Activate the integration of this repository in [Travis-CI](https://travis-ci.org/) signing in with your account and activating `bcbio-nextgen`

Also, and this is important, since the Docker container is running the `bcbio-nextgen` code installed _inside_ the container, this is not testing the latest codebase. To do that, we should find a way of updating the code inside the container before running the testsuite. Is that something that could be easily done?

Thanks!