### PR TITLE
Pull from DockerHub instead of importing the image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
   # Install bcbio-nextgen and bcbio-nextgen-vm
   - export PATH=~/install/bcbio-vm/anaconda/bin/:$PATH
   #- conda install --yes -c bcbio bcbio-nextgen-vm -q #XXX bcbio-nextgen-vm changes not yet in conda
-  - pip install https://github.com/brainstorm/bcbio-nextgen-vm/tree/dockerhub/master
+  - pip install https://github.com/brainstorm/bcbio-nextgen-vm/tarball/dockerhub/master
   - pip install https://github.com/brainstorm/bcbio-nextgen/tarball/dockerhub_nos3/master
   # Get docker container
   - bcbio_vm.py --datadir=${TRAVIS_BUILD_DIR}/tests/data install --tools

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,9 @@ before_install:
 install:
   # Install bcbio-nextgen and bcbio-nextgen-vm
   - export PATH=~/install/bcbio-vm/anaconda/bin/:$PATH
-  - conda install --yes -c bcbio bcbio-nextgen-vm -q
+  #- conda install --yes -c bcbio bcbio-nextgen-vm -q #XXX bcbio-nextgen-vm changes not yet in conda
+  - pip install https://github.com/brainstorm/bcbio-nextgen-vm/tree/dockerhub/master
+  - pip install https://github.com/brainstorm/bcbio-nextgen/tarball/dockerhub_nos3/master
   # Get docker container
   - bcbio_vm.py --datadir=${TRAVIS_BUILD_DIR}/tests/data install --tools
   # Update to bcbio-nextgen latest code within the container

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ language: generic
 env:
   - BCBIO_DOCKER_PRIVILEGED=True
 
+branches:
+  only:
+    - dockerhub_nos3
+
 before_install:
   # Temporal fix for networking problem: https://github.com/travis-ci/travis-ci/issues/1484
   - echo "127.0.1.1 "`hostname` | sudo tee /etc/hosts

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,7 @@ before_install:
 install:
   # Install bcbio-nextgen and bcbio-nextgen-vm
   - export PATH=~/install/bcbio-vm/anaconda/bin/:$PATH
-  #- conda install --yes -c bcbio bcbio-nextgen-vm -q #XXX bcbio-nextgen-vm changes not yet in conda
-  - pip install https://github.com/brainstorm/bcbio-nextgen-vm/tarball/dockerhub/master
-  - pip install https://github.com/brainstorm/bcbio-nextgen/tarball/dockerhub_nos3/master
+  - conda install --yes -c bcbio bcbio-nextgen-vm -q #XXX bcbio-nextgen-vm changes not yet in conda
   # Get docker container
   - bcbio_vm.py --datadir=${TRAVIS_BUILD_DIR}/tests/data install --tools
   # Update to bcbio-nextgen latest code within the container

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,6 @@ language: generic
 env:
   - BCBIO_DOCKER_PRIVILEGED=True
 
-branches:
-  only:
-    - dockerhub_nos3
-
 before_install:
   # Temporal fix for networking problem: https://github.com/travis-ci/travis-ci/issues/1484
   - echo "127.0.1.1 "`hostname` | sudo tee /etc/hosts
@@ -20,7 +16,7 @@ before_install:
 install:
   # Install bcbio-nextgen and bcbio-nextgen-vm
   - export PATH=~/install/bcbio-vm/anaconda/bin/:$PATH
-  - conda install --yes -c bcbio bcbio-nextgen-vm -q #XXX bcbio-nextgen-vm changes not yet in conda
+  - conda install --yes -c bcbio bcbio-nextgen-vm -q
   # Get docker container
   - bcbio_vm.py --datadir=${TRAVIS_BUILD_DIR}/tests/data install --tools
   # Update to bcbio-nextgen latest code within the container

--- a/bcbio/cwl/create.py
+++ b/bcbio/cwl/create.py
@@ -27,7 +27,7 @@ def _standard_bcbio_cwl(samples, inputs):
     """
     return {"class": "Workflow",
             "hints": [{"class": "DockerRequirement",
-                       "dockerImport": "https://s3.amazonaws.com/bcbio_nextgen/bcbio-nextgen-docker-image.gz",
+                       "dockerPull": "bcbio/bcbio",
                        "dockerImageId": "chapmanb/bcbio-nextgen-devel"}],
             "requirements": [{"class": "EnvVarRequirement",
                               "envDef": [{"envName": "MPLCONFIGDIR", "envValue": "."}]}],


### PR DESCRIPTION
This PR is to test whether travis passes without the conda packages and eliminates the need for a specific amazon S3 image.