### PR TITLE
Update vardict.py

### DIFF
--- a/bcbio/variation/vardict.py
+++ b/bcbio/variation/vardict.py
@@ -298,6 +298,8 @@ def get_vardict_command(data):
         if not vardict:
             return None
         vardict = vardict[0]
+    elif not vcaller:
+        return None
     else:
         vardict = vcaller
     vardict = "vardict-java" if not vardict.endswith("-perl") else "vardict"


### PR DESCRIPTION
To return `None` in `get_vardict_command()` when no variant caller is specified