### PR TITLE
Fix typo in gatkfilter.py

### DIFF
--- a/bcbio/variation/gatkfilter.py
+++ b/bcbio/variation/gatkfilter.py
@@ -58,7 +58,7 @@ def _apply_vqsr(in_file, ref_file, recal_file, tranch_file,
             resources = config_utils.get_resources("gatk_apply_recalibration", data["config"])
             opts = resources.get("options", [])
             if not opts:
-                ops += ["--ts_filter_level", sensitivity_cutoff]
+                opts += ["--ts_filter_level", sensitivity_cutoff]
             params += opts
             broad_runner.run_gatk(params)
     return out_file


### PR DESCRIPTION
The typo caused the following error:

```python
Traceback (most recent call last):
  File "/usr/local/bin/bcbio_nextgen.py", line 226, in <module>
    main(**kwargs)
  File "/usr/local/bin/bcbio_nextgen.py", line 43, in main
    run_main(**kwargs)
  File "/usr/local/share/bcbio-nextgen/anaconda/lib/python2.7/site-packages/bcbio/pipeline/main.py", line 39, in run_main
    fc_dir, run_info_yaml)
  File "/usr/local/share/bcbio-nextgen/anaconda/lib/python2.7/site-packages/bcbio/pipeline/main.py", line 82, in _run_toplevel
    for xs in pipeline.run(config, run_info_yaml, parallel, dirs, samples):
  File "/usr/local/share/bcbio-nextgen/anaconda/lib/python2.7/site-packages/bcbio/pipeline/main.py", line 241, in run
    samples = run_parallel("postprocess_variants", samples)
  File "/usr/local/share/bcbio-nextgen/anaconda/lib/python2.7/site-packages/bcbio/distributed/multi.py", line 28, in run_parallel
    return run_multicore(fn, items, config, parallel=parallel)
  File "/usr/local/share/bcbio-nextgen/anaconda/lib/python2.7/site-packages/bcbio/distributed/multi.py", line 86, in run_multicore
    for data in joblib.Parallel(parallel["num_jobs"])(joblib.delayed(fn)(x) for x in items):
  File "/usr/local/share/bcbio-nextgen/anaconda/lib/python2.7/site-packages/joblib/parallel.py", line 657, in __call__
    self.dispatch(function, args, kwargs)
  File "/usr/local/share/bcbio-nextgen/anaconda/lib/python2.7/site-packages/joblib/parallel.py", line 404, in dispatch
    job = ImmediateApply(func, args, kwargs)
  File "/usr/local/share/bcbio-nextgen/anaconda/lib/python2.7/site-packages/joblib/parallel.py", line 142, in __init__
    self.results = func(*args, **kwargs)
  File "/usr/local/share/bcbio-nextgen/anaconda/lib/python2.7/site-packages/bcbio/utils.py", line 51, in wrapper
    return apply(f, *args, **kwargs)
  File "/usr/local/share/bcbio-nextgen/anaconda/lib/python2.7/site-packages/bcbio/distributed/multitasks.py", line 90, in postprocess_variants
    return variation.postprocess_variants(*args)
  File "/usr/local/share/bcbio-nextgen/anaconda/lib/python2.7/site-packages/bcbio/pipeline/variation.py", line 26, in postprocess_variants
    data)
  File "/usr/local/share/bcbio-nextgen/anaconda/lib/python2.7/site-packages/bcbio/variation/genotype.py", line 31, in variant_filtration
    return gatkfilter.run(call_file, ref_file, vrn_files, data)
  File "/usr/local/share/bcbio-nextgen/anaconda/lib/python2.7/site-packages/bcbio/variation/gatkfilter.py", line 22, in run
    vfilter.gatk_snp_hard)
  File "/usr/local/share/bcbio-nextgen/anaconda/lib/python2.7/site-packages/bcbio/variation/gatkfilter.py", line 187, in _variant_filtration
    sensitivities[filter_type], filter_type, data)
  File "/usr/local/share/bcbio-nextgen/anaconda/lib/python2.7/site-packages/bcbio/variation/gatkfilter.py", line 61, in _apply_vqsr
    ops += ["--ts_filter_level", sensitivity_cutoff]
UnboundLocalError: local variable 'ops' referenced before assignment
```
The proposed fix was verified to fix the error.