### PR TITLE
Fix fastq downsampling.

### DIFF
--- a/bcbio/bam/fastq.py
+++ b/bcbio/bam/fastq.py
@@ -179,7 +179,7 @@ def downsample(f1, f2, data, N, quick=False):
     else:
         records = sum(1 for _ in open(f1)) / 4
         N = records if N > records else N
-        rand_records = random.sample(xrange(records), N)
+        rand_records = sorted(random.sample(xrange(records), N))
 
     fh1 = open_possible_gzip(f1)
     fh2 = open_possible_gzip(f2) if f2 else None


### PR DESCRIPTION
If the first element of rand_records is high, there is a chance that it will move to the end in the first iteration of the while loop, and write only 1 read. The rest N-1 readlines will return an empty line.