### PR TITLE
Reverse order of xaxis and calculate deltas accordingly.

### DIFF
--- a/bcbio/graph/graph.py
+++ b/bcbio/graph/graph.py
@@ -99,7 +99,7 @@ def delta_from_prev(prev_values, tstamps, value):
 
     # Take the difference from the previous value and divide by the interval
     # since the previous sample, so we always return values in units/second.
-    return (value - prev_val) / (cur_tstamp - prev_tstamp).seconds
+    return (prev_val - value) / (prev_tstamp - cur_tstamp).seconds
 
 
 def calc_deltas(data_frame, series=None):
@@ -108,7 +108,7 @@ def calc_deltas(data_frame, series=None):
     for the current interval.
     """
     series = series or []
-    data_frame = data_frame.sort(ascending=False)
+    data_frame = data_frame.sort_index(ascending=True)
 
     for s in series:
         prev_values = iter(data_frame[s])


### PR DESCRIPTION
 Thanks @guillermo-carrasco. 

@lpantano: chime in if you have any hints regarding this piece of [matplotlib code](https://github.com/brainstorm/bcbio-nextgen/blob/master/bcbio/graph/graph.py#L166):

```
  top_axis.set_xticks([k for k, v in tick_kvs])
  top_axis.set_xticklabels([v for k, v in tick_kvs],
                             rotation=45, ha='left', size=16)
```

As it is now, the xaxis `steps` annotations get overlapped on the resulting graphs :/

![skarmavbild 2016-01-27 kl 22 28 59](https://cloud.githubusercontent.com/assets/175587/12628834/688bcf86-c545-11e5-80ef-211ce9c3bee2.png)
 