### PR TITLE
bioconda for private bcbio installation 

### DIFF
--- a/docs/contents/installation.rst
+++ b/docs/contents/installation.rst
@@ -305,7 +305,7 @@ The environment can then be switched on with `source activate bcbio` and off
 with `source deactivate`. Activate the environment and install bcbio within it::
 
   source activate bcbio
-  conda install -c bcbio bcbio-nextgen # This will install dependencies
+  conda install --yes -c bioconda bcbio-nextgen # This will install dependencies
   git clone https://github.com/chapmanb/bcbio-nextgen.git
   cd bcbio-nextgen
   python setup.py install


### PR DESCRIPTION
The documentation report conda install -c bcbio bcbio-nextgen for a local bcbio install.
Update the local/private bcbio installation conda to bioconda in the docs.