### PR TITLE
fix the  No such file or directory error

### DIFF
--- a/docs/contents/installation.rst
+++ b/docs/contents/installation.rst
@@ -309,6 +309,7 @@ with `source deactivate`. Activate the environment and install bcbio within it::
   git clone https://github.com/chapmanb/bcbio-nextgen.git
   cd bcbio-nextgen
   python setup.py install
+  ln -s path-to-bcbio/anaconda/bin/* path-to-bcbio/anaconda/envs/bioconda/bin/
 
 If you want to use a different (e.g., system-wide) bcbio installation for
 genomes, indices and the various tools point to that


### PR DESCRIPTION
install a local / private bcbio run in No such file or directory error (e.g.
 /bin/bash: bcbio/anaconda/envs/bioconda/bin/cutadapt: No such file or directory)