### PR TITLE
Remove closing() usage around Pysam Samfile() and Fastafile().

### DIFF
--- a/bcbio/bam/__init__.py
+++ b/bcbio/bam/__init__.py
@@ -1,7 +1,6 @@
 """Functionality to query and extract information from aligned BAM files.
 """
 import collections
-import contextlib
 import os
 import itertools
 import signal
@@ -97,7 +96,7 @@ def get_downsample_pct(in_bam, target_counts, data):
     """Retrieve percentage of file to downsample to get to target counts.
     """
     total = sum(x.aligned for x in idxstats(in_bam, data))
-    with contextlib.closing(pysam.Samfile(in_bam, "rb")) as work_bam:
+    with pysam.Samfile(in_bam, "rb") as work_bam:
         n_rgs = max(1, len(work_bam.header.get("RG", [])))
     rg_target = n_rgs * target_counts
     if total > rg_target:
@@ -141,7 +140,7 @@ def check_header(in_bam, rgnames, ref_file, config):
 def _check_sample(in_bam, rgnames):
     """Ensure input sample name matches expected run group names.
     """
-    with contextlib.closing(pysam.Samfile(in_bam, "rb")) as bamfile:
+    with pysam.Samfile(in_bam, "rb") as bamfile:
         rg = bamfile.header.get("RG", [{}])
     msgs = []
     warnings = []
@@ -165,7 +164,7 @@ def _check_bam_contigs(in_bam, ref_file, config):
     """Ensure a pre-aligned BAM file matches the expected reference genome.
     """
     ref_contigs = [c.name for c in ref.file_contigs(ref_file, config)]
-    with contextlib.closing(pysam.Samfile(in_bam, "rb")) as bamfile:
+    with pysam.Samfile(in_bam, "rb") as bamfile:
         bam_contigs = [c["SN"] for c in bamfile.header["SQ"]]
     problems = []
     warnings = []
@@ -422,7 +421,7 @@ def _get_sort_stem(in_bam, order):
 def sample_name(in_bam):
     """Get sample name from BAM file.
     """
-    with contextlib.closing(pysam.AlignmentFile(in_bam, "rb", check_sq=False)) as in_pysam:
+    with pysam.AlignmentFile(in_bam, "rb", check_sq=False) as in_pysam:
         try:
             if "RG" in in_pysam.header:
                 return in_pysam.header["RG"][0]["SM"]

--- a/bcbio/bam/callable.py
+++ b/bcbio/bam/callable.py
@@ -9,7 +9,6 @@ Regions are split to try to maintain relative uniformity across the
 genome and avoid extremes of large blocks or large numbers of
 small blocks.
 """
-import contextlib
 import copy
 import os
 import shutil
@@ -206,7 +205,7 @@ def get_ref_bedtool(ref_file, config, chrom=None):
     broad_runner = broad.runner_from_path("picard", config)
     ref_dict = broad_runner.run_fn("picard_index_ref", ref_file)
     ref_lines = []
-    with contextlib.closing(pysam.Samfile(ref_dict, "r")) as ref_sam:
+    with pysam.Samfile(ref_dict, "r") as ref_sam:
         for sq in ref_sam.header["SQ"]:
             if not chrom or sq["SN"] == chrom:
                 ref_lines.append("%s\t%s\t%s" % (sq["SN"], 0, sq["LN"]))

--- a/bcbio/broad/metrics.py
+++ b/bcbio/broad/metrics.py
@@ -324,7 +324,7 @@ class PicardMetrics(object):
         metrics_file = "%s.dup_metrics" % os.path.splitext(align_bam)[0]
         if not file_exists(metrics_file):
             dups = 0
-            with contextlib.closing(pysam.Samfile(align_bam, "rb")) as bam_handle:
+            with pysam.Samfile(align_bam, "rb") as bam_handle:
                 for read in bam_handle:
                     if (read.is_paired and read.is_read1) or not read.is_paired:
                         if read.is_duplicate:
@@ -445,8 +445,7 @@ def bed_to_interval(orig_bed, bam_file):
     if line.startswith("@"):
         yield orig_bed
     else:
-        bam_handle = pysam.Samfile(bam_file, "rb")
-        with contextlib.closing(bam_handle):
+        with pysam.Samfile(bam_file, "rb") as bam_handle:
             header = bam_handle.text
         with tmpfile(dir=os.path.dirname(orig_bed), prefix="picardbed") as tmp_bed:
             with open(tmp_bed, "w") as out_handle:

--- a/bcbio/broad/picardrun.py
+++ b/bcbio/broad/picardrun.py
@@ -2,7 +2,6 @@
 """
 import os
 import collections
-from contextlib import closing
 
 import pysam
 
@@ -294,7 +293,7 @@ def bed2interval(align_file, bed, out_file=None):
     if out_file is None:
         out_file = base + ".interval"
 
-    with closing(pysam.Samfile(align_file, "r" if ext.endswith(".sam") else "rb")) as in_bam:
+    with pysam.Samfile(align_file, "r" if ext.endswith(".sam") else "rb") as in_bam:
         header = in_bam.text
 
     def reorder_line(line):

--- a/bcbio/pipeline/shared.py
+++ b/bcbio/pipeline/shared.py
@@ -1,7 +1,7 @@
 """Pipeline functionality shared amongst multiple analysis types.
 """
 import os
-from contextlib import closing, contextmanager
+from contextlib import contextmanager
 import fileinput
 import functools
 import tempfile
@@ -52,7 +52,7 @@ def process_bam_by_chromosome(output_ext, file_key, default_targets=None, remove
         if not file_exists(out_file):
             work_dir = safe_makedir(
                 "{base}-split".format(base=os.path.splitext(out_file)[0]))
-            with closing(pysam.Samfile(bam_file, "rb")) as work_bam:
+            with pysam.Samfile(bam_file, "rb") as work_bam:
                 for chr_ref in list(work_bam.references) + default_targets:
                     if chr_ref not in ignore_chroms:
                         chr_out = os.path.join(work_dir,
@@ -127,13 +127,13 @@ def subset_bam_by_region(in_file, region, config, out_file_base=None):
         base, ext = os.path.splitext(in_file)
     out_file = "%s-subset%s%s" % (base, region, ext)
     if not file_exists(out_file):
-        with closing(pysam.Samfile(in_file, "rb")) as in_bam:
+        with pysam.Samfile(in_file, "rb") as in_bam:
             target_tid = in_bam.gettid(region)
             assert region is not None, \
                    "Did not find reference region %s in %s" % \
                    (region, in_file)
             with file_transaction(config, out_file) as tx_out_file:
-                with closing(pysam.Samfile(tx_out_file, "wb", template=in_bam)) as out_bam:
+                with pysam.Samfile(tx_out_file, "wb", template=in_bam) as out_bam:
                     for read in in_bam:
                         if read.tid == target_tid:
                             out_bam.write(read)

--- a/bcbio/qc/qsignature.py
+++ b/bcbio/qc/qsignature.py
@@ -2,7 +2,6 @@
 
 https://sourceforge.net/p/adamajava/wiki/qSignature/
 """
-import contextlib
 import os
 import shutil
 import subprocess
@@ -168,7 +167,7 @@ def _slice_bam_chr21(in_bam, data):
     out_file = "%s-chr%s" % os.path.splitext(in_bam)
     if not utils.file_exists(out_file):
         bam.index(in_bam, data['config'])
-        with contextlib.closing(pysam.Samfile(in_bam, "rb")) as bamfile:
+        with pysam.Samfile(in_bam, "rb") as bamfile:
             bam_contigs = [c["SN"] for c in bamfile.header["SQ"]]
         chromosome = "21"
         if "chr21" in bam_contigs:

--- a/bcbio/structural/cn_mops.py
+++ b/bcbio/structural/cn_mops.py
@@ -2,7 +2,6 @@
 
 http://www.bioconductor.org/packages/release/bioc/html/cn.mops.html
 """
-from contextlib import closing
 import os
 import re
 import shutil
@@ -33,7 +32,7 @@ def run(items, background=None):
                                                "cn_mops"))
     parallel = {"type": "local", "cores": data["config"]["algorithm"].get("num_cores", 1),
                 "progs": ["delly"]}
-    with closing(pysam.Samfile(work_bams[0], "rb")) as pysam_work_bam:
+    with pysam.Samfile(work_bams[0], "rb") as pysam_work_bam:
         chroms = [None] if _get_regional_bed_file(items[0]) else pysam_work_bam.references
         out_files = run_multicore(_run_on_chrom, [(chrom, work_bams, names, work_dir, items)
                                                   for chrom in chroms],

--- a/bcbio/structural/hydra.py
+++ b/bcbio/structural/hydra.py
@@ -8,7 +8,6 @@ import os
 import copy
 import collections
 import subprocess
-from contextlib import closing
 
 import pysam
 
@@ -34,7 +33,7 @@ def select_unaligned_read_pairs(in_bam, extra, out_dir, config):
                                           ("WRITE_READS_FILES", "false"),
                                           ("SORT_ORDER", "queryname")])
     has_reads = False
-    with closing(pysam.Samfile(nomap_bam, "rb")) as in_pysam:
+    with pysam.Samfile(nomap_bam, "rb") as in_pysam:
         for read in in_pysam:
             if read.is_paired:
                 has_reads = True
@@ -54,13 +53,13 @@ def remove_nopairs(in_bam, out_dir, config):
                                           os.path.splitext(os.path.basename(in_bam))))
     if not utils.file_exists(out_bam):
         read_counts = collections.defaultdict(int)
-        with closing(pysam.Samfile(in_bam, "rb")) as in_pysam:
+        with pysam.Samfile(in_bam, "rb") as in_pysam:
             for read in in_pysam:
                 if read.is_paired:
                     read_counts[read.qname] += 1
-        with closing(pysam.Samfile(in_bam, "rb")) as in_pysam:
+        with pysam.Samfile(in_bam, "rb") as in_pysam:
             with file_transaction(out_bam) as tx_out_bam:
-                with closing(pysam.Samfile(tx_out_bam, "wb", template=in_pysam)) as out_pysam:
+                with pysam.Samfile(tx_out_bam, "wb", template=in_pysam) as out_pysam:
                     for read in in_pysam:
                         if read_counts[read.qname] == 2:
                             out_pysam.write(read)

--- a/bcbio/structural/shared.py
+++ b/bcbio/structural/shared.py
@@ -3,7 +3,6 @@
 Handles exclusion regions and preparing discordant regions.
 """
 import collections
-from contextlib import closing
 import os
 
 import numpy
@@ -204,7 +203,7 @@ def get_sv_chroms(items, exclude_file):
         if int(region.start) == 0:
             exclude_regions[region.chrom] = int(region.end)
     out = []
-    with closing(pysam.Samfile(items[0]["work_bam"], "rb")) as pysam_work_bam:
+    with pysam.Samfile(items[0]["work_bam"], "rb") as pysam_work_bam:
         for chrom, length in zip(pysam_work_bam.references, pysam_work_bam.lengths):
             exclude_length = exclude_regions.get(chrom, 0)
             if exclude_length < length:
@@ -302,7 +301,7 @@ def calc_paired_insert_stats(in_bam, nsample=1000000):
     """
     dists = []
     n = 0
-    with closing(pysam.Samfile(in_bam, "rb")) as in_pysam:
+    with pysam.Samfile(in_bam, "rb") as in_pysam:
         for read in in_pysam:
             if read.is_proper_pair and read.is_read1:
                 n += 1

--- a/bcbio/variation/cortex.py
+++ b/bcbio/variation/cortex.py
@@ -12,7 +12,6 @@ import glob
 import subprocess
 import itertools
 import shutil
-from contextlib import closing
 
 import pysam
 from Bio import Seq
@@ -284,7 +283,7 @@ def _get_local_ref(region, ref_file, out_vcf_base):
     """
     out_file = "{0}.fa".format(out_vcf_base)
     if not file_exists(out_file):
-        with closing(pysam.Fastafile(ref_file)) as in_pysam:
+        with pysam.Fastafile(ref_file) as in_pysam:
             contig, start, end = region
             seq = in_pysam.fetch(contig, int(start), int(end))
             with open(out_file, "w") as out_handle:
@@ -302,7 +301,7 @@ def _get_fastq_in_region(region, align_bam, out_base):
     """
     out_file = "{0}.fastq".format(out_base)
     if not file_exists(out_file):
-        with closing(pysam.Samfile(align_bam, "rb")) as in_pysam:
+        with pysam.Samfile(align_bam, "rb") as in_pysam:
             with file_transaction(out_file) as tx_out_file:
                 with open(tx_out_file, "w") as out_handle:
                     contig, start, end = region
@@ -327,6 +326,6 @@ def _count_fastq_reads(in_fastq, min_reads):
     return len(items)
 
 def get_sample_name(align_bam):
-    with closing(pysam.Samfile(align_bam, "rb")) as in_pysam:
+    with pysam.Samfile(align_bam, "rb") as in_pysam:
         if "RG" in in_pysam.header:
             return in_pysam.header["RG"][0]["SM"]

--- a/bcbio/variation/joint.py
+++ b/bcbio/variation/joint.py
@@ -8,7 +8,6 @@ and FreeBayes's N+1 approach (https://groups.google.com/d/msg/freebayes/-GK4zI6N
 as implemented in bcbio.variation.recall (https://github.com/chapmanb/bcbio.variation.recall).
 """
 import collections
-import contextlib
 import math
 import os
 
@@ -37,7 +36,7 @@ def _get_callable_regions(data):
     else:
         work_bam = list(tz.take(1, filter(lambda x: x.endswith(".bam"), data["work_bams"])))
         if work_bam:
-            with contextlib.closing(pysam.Samfile(work_bam[0], "rb")) as pysam_bam:
+            with pysam.Samfile(work_bam[0], "rb") as pysam_bam:
                 regions = [(chrom, 0, length) for (chrom, length) in zip(pysam_bam.references,
                                                                          pysam_bam.lengths)]
         else:

--- a/bcbio/variation/realign.py
+++ b/bcbio/variation/realign.py
@@ -2,8 +2,6 @@
 """
 import os
 import shutil
-from contextlib import closing
-
 import pysam
 
 from bcbio import bam, broad
@@ -87,7 +85,7 @@ def has_aligned_reads(align_bam, region=None):
             regions = [tuple(r) for r in pybedtools.BedTool(region)]
         else:
             regions = [region]
-    with closing(pysam.Samfile(align_bam, "rb")) as cur_bam:
+    with pysam.Samfile(align_bam, "rb") as cur_bam:
         if region is not None:
             for region in regions:
                 if isinstance(region, basestring):

--- a/bcbio/variation/varscan.py
+++ b/bcbio/variation/varscan.py
@@ -3,7 +3,6 @@
 http://varscan.sourceforge.net/
 """
 
-import contextlib
 import os
 import sys
 
@@ -268,7 +267,7 @@ def _create_sample_list(in_bams, vcf_file):
     out_file = "%s-sample_list.txt" % os.path.splitext(vcf_file)[0]
     with open(out_file, "w") as out_handle:
         for in_bam in in_bams:
-            with contextlib.closing(pysam.Samfile(in_bam, "rb")) as work_bam:
+            with pysam.Samfile(in_bam, "rb") as work_bam:
                 for rg in work_bam.header.get("RG", []):
                     out_handle.write("%s\n" % rg["SM"])
     return out_file

--- a/scripts/utils/collect_metrics_to_csv.py
+++ b/scripts/utils/collect_metrics_to_csv.py
@@ -9,7 +9,6 @@ import os
 import csv
 import glob
 import collections
-import contextlib
 
 import yaml
 import pysam
@@ -156,7 +155,7 @@ def _generate_metrics(bam_fname, config_file, ref_file,
     return out_dir
 
 def _bam_is_paired(bam_fname):
-    with contextlib.closing(pysam.Samfile(bam_fname, "rb")) as work_bam:
+    with pysam.Samfile(bam_fname, "rb") as work_bam:
         for read in work_bam:
             if not read.is_unmapped:
                 return read.is_paired


### PR DESCRIPTION
Pysam has implemented the context manager interface for quite a while
now, so the closing() calls are redundant.