### PR TITLE
Remove unused list _out_fnames.

### DIFF
--- a/bcbio/ngsalign/tophat.py
+++ b/bcbio/ngsalign/tophat.py
@@ -26,10 +26,6 @@ from bcbio import broad
 import bcbio.pipeline.datadict as dd
 
 
-_out_fnames = ["accepted_hits.sam", "junctions.bed",
-               "insertions.bed", "deletions.bed"]
-
-
 def _set_quality_flag(options, data):
     qual_format = dd.get_quality_format(data)
     if qual_format.lower() == "illumina":


### PR DESCRIPTION
Small follow-up cleanup in relation to #1511 ; the (unused) list _out_fnames contained the now stale filename accepted_hits.sam.