### PR TITLE
Tophat fixes

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -13,7 +13,7 @@
 - Allow non-positional UMI Rapmap quantified single-cell RNA-seq.
 - Re-enable save_diskspace option to reduce disk usage during alignment
   preparation and split alignments.
-- Offload fixing the unmapped Tophat file to tophat-recondition. Thanks to Christian Bruenner.
+- Offload fixing the unmapped Tophat file to tophat-recondition. Thanks to Christian Brueffer.
 - Add support for vcfanno (https://github.com/brentp/vcfanno) to annotate VCFs with other 
   VCFs/BED files. 
 - Mark possible RNA-edits for GRCh37/hg19 using RADAR coordinates. Thanks to Sergey Naumenko

--- a/bcbio/ngsalign/tophat.py
+++ b/bcbio/ngsalign/tophat.py
@@ -153,8 +153,8 @@ def tophat_align(fastq_file, pair_file, ref_file, out_base, align_dir, data,
     fixed = bam.sort(fixed, config)
     picard = broad.runner_from_path("picard", config)
     # set the contig order to match the reference file so GATK works
-    fixed = picard.run_fn("picard_reorder", out_file, data["sam_ref"],
-                          os.path.splitext(out_file)[0] + ".picard.bam")
+    fixed = picard.run_fn("picard_reorder", fixed, data["sam_ref"],
+                          os.path.splitext(fixed)[0] + ".picard.bam")
     fixed = fix_insert_size(fixed, config)
     if not file_exists(final_out):
         symlink_plus(fixed, final_out)

--- a/config/genomes/hg38-noalt-resources.yaml
+++ b/config/genomes/hg38-noalt-resources.yaml
@@ -17,7 +17,7 @@ rnaseq:
   transcripts: ../rnaseq/ref-transcripts.gtf
   transcripts_mask: ../rnaseq/ref-transcripts-mask.gtf
   transcriptome_index:
-    tophat: ../rnaseq/tophat/hg19_transcriptome.ver
+    tophat: ../rnaseq/tophat/hg38-noalt_transcriptome.ver
   dexseq: ../rnaseq/ref-transcripts.dexseq.gff3
   refflat: ../rnaseq/ref-transcripts.refFlat
   rRNA_fa: ../rnaseq/rRNA.fa

--- a/config/genomes/hg38-resources.yaml
+++ b/config/genomes/hg38-resources.yaml
@@ -19,7 +19,7 @@ rnaseq:
   transcripts: ../rnaseq/ref-transcripts.gtf
   transcripts_mask: ../rnaseq/ref-transcripts-mask.gtf
   transcriptome_index:
-    tophat: ../rnaseq/tophat/hg19_transcriptome.ver
+    tophat: ../rnaseq/tophat/hg38_transcriptome.ver
   dexseq: ../rnaseq/ref-transcripts.dexseq.gff3
   refflat: ../rnaseq/ref-transcripts.refFlat
   rRNA_fa: ../rnaseq/rRNA.fa


### PR DESCRIPTION
More fixes for TopHat:
- actually use the merged BAM file (mapped + unmapped); previously the wrapper would continue with the mapped file
- fix transcriptome index file names for hg38 and hg38-noalt; previously the transcriptome indexes would be rebuilt during every TopHat run