### PR TITLE
Improvements in caching bed files. Fix counting genes.

### DIFF
--- a/bcbio/qc/qualimap.py
+++ b/bcbio/qc/qualimap.py
@@ -65,7 +65,7 @@ def run(bam_file, data, out_dir):
             species = "MOUSE"
         if species in ["HUMAN", "MOUSE"]:
             cmd += " -gd {species}"
-        regions = bedutils.merge_overlaps(dd.get_coverage(data) or dd.get_variant_regions(data), data)
+        regions = bedutils.merge_overlaps(dd.get_coverage(data), data) or dd.get_variant_regions_merged(data)
         if regions:
             bed6_regions = _bed_to_bed6(regions, out_dir)
             cmd += " -gff {bed6_regions}"

--- a/bcbio/structural/seq2c.py
+++ b/bcbio/structural/seq2c.py
@@ -19,6 +19,7 @@ from bcbio.provenance import do
 from bcbio.structural import annotate, regions
 from bcbio.log import logger
 from bcbio.variation.coverage import regions_coverage
+from bcbio.variation.bedutils import clean_file
 
 
 def precall(items):
@@ -32,8 +33,7 @@ def precall(items):
     assert dd.get_coverage_interval(data) != "genome", "Seq2C only for amplicon and exome sequencing"
 
     work_dir = _sv_workdir(data)
-    bed_file = regions.get_sv_bed(data) or dd.get_variant_regions(data)
-    bed_file = _prep_bed(data, bed_file, work_dir)
+    bed_file = _prep_bed(data, work_dir)
     bam_file = dd.get_align_bam(data)
     sample_name = dd.get_sample_name(data)
 
@@ -65,41 +65,34 @@ def run(items):
 
     return items
 
-def _prep_bed(data, bed_file, work_dir):
-    clean_file = os.path.join(work_dir, "%s-clean.bed" % (utils.splitext_plus(os.path.basename(bed_file))[0]))
-    bed = bt.BedTool(bed_file)
-    col_num = bed.field_count()
+def _prep_bed(data, work_dir):
+    """Selecting the bed file, cleaning, and properly annotating for Seq2C
+    """
+    bed_file = regions.get_sv_bed(data)
+    if bed_file:
+        bed_file = clean_file(bed_file, data, prefix="svregions-")
+    else:
+        bed_file = clean_file(dd.get_variant_regions(data), data)
 
-    if not utils.file_uptodate(clean_file, bed_file):
-        bed = bed.filter(lambda x: x.chrom and
-                         not any(x.chrom.startswith(e) for e in ['#', ' ', 'track', 'browser']))
-        bed = bed.remove_invalid()
-        with file_transaction(data, clean_file) as tx_out_file:
-            bed.saveas(tx_out_file)
-        logger.debug("Saved Seq2C clean BED file into " + clean_file)
-
+    col_num = bt.BedTool(bed_file).field_count()
     if col_num < 4:
-        annotated_file = annotate.add_genes(clean_file, data, max_distance=0, work_dir=work_dir)
-        if annotated_file == clean_file:
+        annotated_file = annotate.add_genes(bed_file, data, max_distance=0)
+        if annotated_file == bed_file:
             raise ValueError("BED file for Seq2C must be annotated with gene names, "
                              "however the input BED is 3-columns and we have no transcript "
                              "data to annotate with " + bed_file)
+        annotated_file = annotate.gene_one_per_line(annotated_file, data)
     else:
-        annotated_file = clean_file
+        annotated_file = bed_file
 
-    ready_file = os.path.join(work_dir, "%s-clean.bed" % (utils.splitext_plus(os.path.basename(annotated_file))[0]))
+    ready_file = "%s-seq2cclean.bed" % (utils.splitext_plus(annotated_file)[0])
     if not utils.file_uptodate(ready_file, annotated_file):
         bed = bt.BedTool(annotated_file)
         if col_num > 4 and col_num != 8:
             bed = bed.cut(range(4))
         bed = bed.filter(lambda x: x.name not in ["", ".", "-"])
-
-        # Report all duplicated annotations one-per-line
         with file_transaction(data, ready_file) as tx_out_file:
-            with open(tx_out_file, 'w') as out:
-                for r in bed:
-                    for g in r.name.split(','):
-                        out.write('\t'.join(map(str, [r.chrom, r.start, r.end, g])) + '\n')
+            bed.saveas(tx_out_file)
         logger.debug("Saved Seq2C clean annotated ready input BED into " + ready_file)
 
     return ready_file

--- a/bcbio/variation/coverage.py
+++ b/bcbio/variation/coverage.py
@@ -488,7 +488,7 @@ def priority_total_coverage(data, out_dir):
     if not bed_file and not file_exists(bed_file) or prioritize.is_gene_list(bed_file):
         return {}
     in_bam = dd.get_align_bam(data) or dd.get_work_bam(data)
-    cleaned_bed = clean_file(bed_file, data)
+    cleaned_bed = clean_file(bed_file, data, prefix="svprioritize-")
     work_dir = safe_makedir(out_dir)
     sample = dd.get_sample_name(data)
     out_file = os.path.join(work_dir, sample + "_priority_total_coverage.bed")

--- a/bcbio/variation/validate.py
+++ b/bcbio/variation/validate.py
@@ -122,7 +122,7 @@ def compare_to_rm(data):
         rm_interval_file = _gunzip(normalize_input_path(toval_data["config"]["algorithm"].get("validate_regions"),
                                                         toval_data),
                                    toval_data)
-        rm_interval_file = bedutils.clean_file(rm_interval_file, toval_data,
+        rm_interval_file = bedutils.clean_file(rm_interval_file, toval_data, prefix="validateregions-",
                                                bedprep_dir=utils.safe_makedir(os.path.join(base_dir, "bedprep")))
         rm_file = naming.handle_synonyms(rm_file, dd.get_ref_file(data), data.get("genome_build"), base_dir, data)
         rm_interval_file = (naming.handle_synonyms(rm_interval_file, dd.get_ref_file(data),


### PR DESCRIPTION
Few clean-up and edge-case scenario updates before the release.

1. I reviewed caching of `clean_file()` and `add_genes()` across the pipeline and made sure that the proper prefix (like `cov-`, `svprioritize-`, `svregions-`) is provided wherever needed for correct caching. 
2. Counting genes for MultiQC: if the BED is pre-annotated, skip re-annotating and count original feature names. If we failed to annotate bed, skip reporting the count. Also handle comma-separated names and dots, and cleaning files before add_genes.
3. Reusing `clean_file()` in `seq2c.py`, cleaning redundancy in `_prep_bed()`.
4. Minor fixes and inline comments in `bedutils.py`.