### PR TITLE
made dbNSFP fields modifiable, added dbNSFP for hg38

### DIFF
--- a/bcbio/variation/effects.py
+++ b/bcbio/variation/effects.py
@@ -131,6 +131,7 @@ def run_vep(in_file, data):
                 if is_human:
                     dbnsfp_args, dbnsfp_fields = _get_dbnsfp(data)
                     loftee_args, loftee_fields = _get_loftee(data)
+                    dbscsnv_args, dbscsnv_fields = _get_dbscsnv(data)
                     prediction_args = ["--sift", "b", "--polyphen", "b"]
                     prediction_fields = ["PolyPhen", "SIFT"]
                 else:

--- a/bcbio/variation/effects.py
+++ b/bcbio/variation/effects.py
@@ -190,6 +190,18 @@ def _get_loftee(data):
     args = ["--plugin", "LoF,human_ancestor_fa:%s" % ancestral_file]
     return args, annotations
 
+def _get_dbscsnv(data):
+    """
+    dbscSNV includes all potential human SNVs within splicing consensus regions
+    (−3 to +8 at the 5’ splice site and −12 to +2 at the 3’ splice site), i.e. scSNVs,
+    related functional annotations and two ensemble prediction scores for predicting their potential of altering splicing.
+    """
+    dbscsnv_file = tz.get_in(("genome_resources", "variation", "dbscsnv"), data)
+    if dbscsnv_file and os.path.exists(dbscsnv_file):
+        return ["--plugin", "dbscSNV,%s" % (dbnsfp_file)], []
+    else:
+        return [], []
+
 # ## snpEff variant effects
 
 def snpeff_version(args=None, data=None):

--- a/bcbio/variation/effects.py
+++ b/bcbio/variation/effects.py
@@ -173,10 +173,9 @@ def _get_dbnsfp(data):
     https://groups.google.com/d/msg/gemini-variation/WeZ6C2YvfUA/mII9uum_pGoJ
     """
     dbnsfp_file = tz.get_in(("genome_resources", "variation", "dbnsfp"), data)
+    annotations = tz.get_in(("genome_resources", "variation", "dbnsfp_fields"), data)
     if dbnsfp_file and os.path.exists(dbnsfp_file):
-        annotations = ["RadialSVM_score", "RadialSVM_pred", "LR_score", "LR_pred", "MutationTaster_score", "MutationTaster_pred", "FATHMM_score", "FATHMM_pred", "PROVEAN_score", "PROVEAN_pred", "MetaSVM_score", "MetaSVM_pred",
-                       "CADD_raw", "CADD_phred", "Reliability_index"]
-        return ["--plugin", "dbNSFP,%s,%s" % (dbnsfp_file, ",".join(annotations))], annotations
+        return ["--plugin", "dbNSFP,%s,%s" % (dbnsfp_file, annotations)], annotations
     else:
         return [], []
 

--- a/bcbio/variation/effects.py
+++ b/bcbio/variation/effects.py
@@ -131,7 +131,6 @@ def run_vep(in_file, data):
                 if is_human:
                     dbnsfp_args, dbnsfp_fields = _get_dbnsfp(data)
                     loftee_args, loftee_fields = _get_loftee(data)
-                    dbscsnv_args, dbscsnv_fields = _get_dbscsnv(data)
                     prediction_args = ["--sift", "b", "--polyphen", "b"]
                     prediction_fields = ["PolyPhen", "SIFT"]
                 else:
@@ -191,17 +190,6 @@ def _get_loftee(data):
     args = ["--plugin", "LoF,human_ancestor_fa:%s" % ancestral_file]
     return args, annotations
 
-def _get_dbscsnv(data):
-    """
-    dbscSNV includes all potential human SNVs within splicing consensus regions
-    (−3 to +8 at the 5’ splice site and −12 to +2 at the 3’ splice site), i.e. scSNVs,
-    related functional annotations and two ensemble prediction scores for predicting their potential of altering splicing.
-    """
-    dbscsnv_file = tz.get_in(("genome_resources", "variation", "dbscsnv"), data)
-    if dbscsnv_file and os.path.exists(dbscsnv_file):
-        return ["--plugin", "dbscSNV,%s" % (dbnsfp_file)], []
-    else:
-        return [], []
 
 # ## snpEff variant effects
 

--- a/config/genomes/GRCh37-resources.yaml
+++ b/config/genomes/GRCh37-resources.yaml
@@ -16,6 +16,7 @@ variation:
   sv_repeat: ../coverage/problem_regions/repeats/sv_repeat_telomere_centromere.bed
   encode_blacklist: ../coverage/problem_regions/ENCODE/wgEncodeDacMapabilityConsensusExcludable.bed.gz
   dbnsfp: ../variation/dbNSFP.txt.gz
+  dbnsfp_fields: LRT_score,LRT_converted_rankscore,LRT_pred,MutationTaster_score,MutationTaster_converted_rankscore,MutationTaster_pred,MutationAssessor_score,MutationAssessor_rankscore,MutationAssessor_pred,FATHMM_score,FATHMM_rankscore,FATHMM_pred,MetaSVM_score,MetaSVM_rankscore,MetaSVM_pred,MetaLR_score,MetaLR_rankscore,MetaLR_pred,Reliability_index,VEST3_score,VEST3_rankscore,PROVEAN_score,PROVEAN_converted_rankscore,PROVEAN_pred,CADD_raw,CADD_raw_rankscore,CADD_phred,GERP++_NR,GERP++_RS,GERP++_RS_rankscore,phyloP46way_primate,phyloP46way_primate_rankscore,phyloP46way_placental,phyloP46way_placental_rankscore,phyloP100way_vertebrate,phyloP100way_vertebrate_rankscore,phastCons46way_primate,phastCons46way_primate_rankscore,phastCons46way_placental,phastCons46way_placental_rankscore,phastCons100way_vertebrate,phastCons100way_vertebrate_rankscore,SiPhy_29way_pi,SiPhy_29way_logOdds,SiPhy_29way_logOdds_rankscore,LRT_Omega,UniSNP_ids,ARIC5606_AA_AC,ARIC5606_AA_AF,ARIC5606_EA_AC,ARIC5606_EA_AF,clinvar_rs,clinvar_clnsig,clinvar_trait,COSMIC_ID,COSMIC_CNT
   ancestral: ../variation/human_ancestor.fa.gz
   qsignature: ../variation/qsignature.vcf
 

--- a/config/genomes/GRCh37-resources.yaml
+++ b/config/genomes/GRCh37-resources.yaml
@@ -17,7 +17,6 @@ variation:
   encode_blacklist: ../coverage/problem_regions/ENCODE/wgEncodeDacMapabilityConsensusExcludable.bed.gz
   dbnsfp: ../variation/dbNSFP.txt.gz
   dbnsfp_fields: RadialSVM_score,RadialSVM_pred,LR_score,LR_pred,MutationTaster_score,MutationTaster_pred,FATHMM_score,FATHMM_pred,PROVEAN_score,PROVEAN_pred,MetaSVM_score,MetaSVM_pred,CADD_raw,CADD_phred,Reliability_index
-  dbscsnv: ../variation/dbscSNV.txt.gz
   ancestral: ../variation/human_ancestor.fa.gz
   qsignature: ../variation/qsignature.vcf
 

--- a/config/genomes/GRCh37-resources.yaml
+++ b/config/genomes/GRCh37-resources.yaml
@@ -17,6 +17,7 @@ variation:
   encode_blacklist: ../coverage/problem_regions/ENCODE/wgEncodeDacMapabilityConsensusExcludable.bed.gz
   dbnsfp: ../variation/dbNSFP.txt.gz
   dbnsfp_fields: RadialSVM_score,RadialSVM_pred,LR_score,LR_pred,MutationTaster_score,MutationTaster_pred,FATHMM_score,FATHMM_pred,PROVEAN_score,PROVEAN_pred,MetaSVM_score,MetaSVM_pred,CADD_raw,CADD_phred,Reliability_index
+  dbscsnv: ../variation/dbscSNV.txt.gz
   ancestral: ../variation/human_ancestor.fa.gz
   qsignature: ../variation/qsignature.vcf
 

--- a/config/genomes/GRCh37-resources.yaml
+++ b/config/genomes/GRCh37-resources.yaml
@@ -16,7 +16,7 @@ variation:
   sv_repeat: ../coverage/problem_regions/repeats/sv_repeat_telomere_centromere.bed
   encode_blacklist: ../coverage/problem_regions/ENCODE/wgEncodeDacMapabilityConsensusExcludable.bed.gz
   dbnsfp: ../variation/dbNSFP.txt.gz
-  dbnsfp_fields: LRT_score,LRT_converted_rankscore,LRT_pred,MutationTaster_score,MutationTaster_converted_rankscore,MutationTaster_pred,MutationAssessor_score,MutationAssessor_rankscore,MutationAssessor_pred,FATHMM_score,FATHMM_rankscore,FATHMM_pred,MetaSVM_score,MetaSVM_rankscore,MetaSVM_pred,MetaLR_score,MetaLR_rankscore,MetaLR_pred,Reliability_index,VEST3_score,VEST3_rankscore,PROVEAN_score,PROVEAN_converted_rankscore,PROVEAN_pred,CADD_raw,CADD_raw_rankscore,CADD_phred,GERP++_NR,GERP++_RS,GERP++_RS_rankscore,phyloP46way_primate,phyloP46way_primate_rankscore,phyloP46way_placental,phyloP46way_placental_rankscore,phyloP100way_vertebrate,phyloP100way_vertebrate_rankscore,phastCons46way_primate,phastCons46way_primate_rankscore,phastCons46way_placental,phastCons46way_placental_rankscore,phastCons100way_vertebrate,phastCons100way_vertebrate_rankscore,SiPhy_29way_pi,SiPhy_29way_logOdds,SiPhy_29way_logOdds_rankscore,LRT_Omega,UniSNP_ids,ARIC5606_AA_AC,ARIC5606_AA_AF,ARIC5606_EA_AC,ARIC5606_EA_AF,clinvar_rs,clinvar_clnsig,clinvar_trait,COSMIC_ID,COSMIC_CNT
+  dbnsfp_fields: RadialSVM_score,RadialSVM_pred,LR_score,LR_pred,MutationTaster_score,MutationTaster_pred,FATHMM_score,FATHMM_pred,PROVEAN_score,PROVEAN_pred,MetaSVM_score,MetaSVM_pred,CADD_raw,CADD_phred,Reliability_index
   ancestral: ../variation/human_ancestor.fa.gz
   qsignature: ../variation/qsignature.vcf
 

--- a/config/genomes/hg19-resources.yaml
+++ b/config/genomes/hg19-resources.yaml
@@ -16,6 +16,7 @@ variation:
   sv_repeat: ../coverage/problem_regions/repeats/sv_repeat_telomere_centromere.bed
   encode_blacklist: ../coverage/problem_regions/ENCODE/wgEncodeDacMapabilityConsensusExcludable.bed.gz
   dbnsfp: ../variation/dbNSFP.txt.gz
+  dbnsfp_fields: LRT_score,LRT_converted_rankscore,LRT_pred,MutationTaster_score,MutationTaster_converted_rankscore,MutationTaster_pred,MutationAssessor_score,MutationAssessor_rankscore,MutationAssessor_pred,FATHMM_score,FATHMM_rankscore,FATHMM_pred,MetaSVM_score,MetaSVM_rankscore,MetaSVM_pred,MetaLR_score,MetaLR_rankscore,MetaLR_pred,Reliability_index,VEST3_score,VEST3_rankscore,PROVEAN_score,PROVEAN_converted_rankscore,PROVEAN_pred,CADD_raw,CADD_raw_rankscore,CADD_phred,GERP++_NR,GERP++_RS,GERP++_RS_rankscore,phyloP46way_primate,phyloP46way_primate_rankscore,phyloP46way_placental,phyloP46way_placental_rankscore,phyloP100way_vertebrate,phyloP100way_vertebrate_rankscore,phastCons46way_primate,phastCons46way_primate_rankscore,phastCons46way_placental,phastCons46way_placental_rankscore,phastCons100way_vertebrate,phastCons100way_vertebrate_rankscore,SiPhy_29way_pi,SiPhy_29way_logOdds,SiPhy_29way_logOdds_rankscore,LRT_Omega,UniSNP_ids,ARIC5606_AA_AC,ARIC5606_AA_AF,ARIC5606_EA_AC,ARIC5606_EA_AF,clinvar_rs,clinvar_clnsig,clinvar_trait,COSMIC_ID,COSMIC_CNT
   ancestral: ../variation/human_ancestor.fa.gz
   qsignature: ../variation/qsignature.vcf
 

--- a/config/genomes/hg19-resources.yaml
+++ b/config/genomes/hg19-resources.yaml
@@ -17,7 +17,6 @@ variation:
   encode_blacklist: ../coverage/problem_regions/ENCODE/wgEncodeDacMapabilityConsensusExcludable.bed.gz
   dbnsfp: ../variation/dbNSFP.txt.gz
   dbnsfp_fields: RadialSVM_score,RadialSVM_pred,LR_score,LR_pred,MutationTaster_score,MutationTaster_pred,FATHMM_score,FATHMM_pred,PROVEAN_score,PROVEAN_pred,MetaSVM_score,MetaSVM_pred,CADD_raw,CADD_phred,Reliability_index
-  dbscsnv: ../variation/dbscSNV.txt.gz
   ancestral: ../variation/human_ancestor.fa.gz
   qsignature: ../variation/qsignature.vcf
 

--- a/config/genomes/hg19-resources.yaml
+++ b/config/genomes/hg19-resources.yaml
@@ -17,6 +17,7 @@ variation:
   encode_blacklist: ../coverage/problem_regions/ENCODE/wgEncodeDacMapabilityConsensusExcludable.bed.gz
   dbnsfp: ../variation/dbNSFP.txt.gz
   dbnsfp_fields: RadialSVM_score,RadialSVM_pred,LR_score,LR_pred,MutationTaster_score,MutationTaster_pred,FATHMM_score,FATHMM_pred,PROVEAN_score,PROVEAN_pred,MetaSVM_score,MetaSVM_pred,CADD_raw,CADD_phred,Reliability_index
+  dbscsnv: ../variation/dbscSNV.txt.gz
   ancestral: ../variation/human_ancestor.fa.gz
   qsignature: ../variation/qsignature.vcf
 

--- a/config/genomes/hg19-resources.yaml
+++ b/config/genomes/hg19-resources.yaml
@@ -16,7 +16,7 @@ variation:
   sv_repeat: ../coverage/problem_regions/repeats/sv_repeat_telomere_centromere.bed
   encode_blacklist: ../coverage/problem_regions/ENCODE/wgEncodeDacMapabilityConsensusExcludable.bed.gz
   dbnsfp: ../variation/dbNSFP.txt.gz
-  dbnsfp_fields: LRT_score,LRT_converted_rankscore,LRT_pred,MutationTaster_score,MutationTaster_converted_rankscore,MutationTaster_pred,MutationAssessor_score,MutationAssessor_rankscore,MutationAssessor_pred,FATHMM_score,FATHMM_rankscore,FATHMM_pred,MetaSVM_score,MetaSVM_rankscore,MetaSVM_pred,MetaLR_score,MetaLR_rankscore,MetaLR_pred,Reliability_index,VEST3_score,VEST3_rankscore,PROVEAN_score,PROVEAN_converted_rankscore,PROVEAN_pred,CADD_raw,CADD_raw_rankscore,CADD_phred,GERP++_NR,GERP++_RS,GERP++_RS_rankscore,phyloP46way_primate,phyloP46way_primate_rankscore,phyloP46way_placental,phyloP46way_placental_rankscore,phyloP100way_vertebrate,phyloP100way_vertebrate_rankscore,phastCons46way_primate,phastCons46way_primate_rankscore,phastCons46way_placental,phastCons46way_placental_rankscore,phastCons100way_vertebrate,phastCons100way_vertebrate_rankscore,SiPhy_29way_pi,SiPhy_29way_logOdds,SiPhy_29way_logOdds_rankscore,LRT_Omega,UniSNP_ids,ARIC5606_AA_AC,ARIC5606_AA_AF,ARIC5606_EA_AC,ARIC5606_EA_AF,clinvar_rs,clinvar_clnsig,clinvar_trait,COSMIC_ID,COSMIC_CNT
+  dbnsfp_fields: RadialSVM_score,RadialSVM_pred,LR_score,LR_pred,MutationTaster_score,MutationTaster_pred,FATHMM_score,FATHMM_pred,PROVEAN_score,PROVEAN_pred,MetaSVM_score,MetaSVM_pred,CADD_raw,CADD_phred,Reliability_index
   ancestral: ../variation/human_ancestor.fa.gz
   qsignature: ../variation/qsignature.vcf
 

--- a/config/genomes/hg38-noalt-resources.yaml
+++ b/config/genomes/hg38-noalt-resources.yaml
@@ -9,7 +9,6 @@ variation:
   dbsnp: ../variation/dbsnp-147.vcf.gz
   dbnsfp: ../variation/dbNSFP.txt.gz
   dbnsfp_fields: RadialSVM_score,RadialSVM_pred,LR_score,LR_pred,MutationTaster_score,MutationTaster_pred,FATHMM_score,FATHMM_pred,PROVEAN_score,PROVEAN_pred,MetaSVM_score,MetaSVM_pred,CADD_raw,CADD_phred,Reliability_index
-  dbscsnv: ../variation/dbscSNV.txt.gz
   train_hapmap: ../variation/hapmap_3.3.vcf.gz
   train_omni: ../variation/1000G_omni2.5.vcf.gz
   train_1000g: ../variation/1000G_phase1.snps.high_confidence.vcf.gz

--- a/config/genomes/hg38-noalt-resources.yaml
+++ b/config/genomes/hg38-noalt-resources.yaml
@@ -8,7 +8,7 @@ aliases:
 variation:
   dbsnp: ../variation/dbsnp-147.vcf.gz
   dbnsfp: ../variation/dbNSFP.txt.gz
-  dbnsfp_fields: LRT_score,LRT_converted_rankscore,LRT_pred,MutationTaster_score,MutationTaster_converted_rankscore,MutationTaster_pred,MutationAssessor_score,MutationAssessor_rankscore,MutationAssessor_pred,FATHMM_score,FATHMM_rankscore,FATHMM_pred,MetaSVM_score,MetaSVM_rankscore,MetaSVM_pred,MetaLR_score,MetaLR_rankscore,MetaLR_pred,Reliability_index,VEST3_score,VEST3_rankscore,PROVEAN_score,PROVEAN_converted_rankscore,PROVEAN_pred,CADD_raw,CADD_raw_rankscore,CADD_phred,GERP++_NR,GERP++_RS,GERP++_RS_rankscore,phyloP46way_primate,phyloP46way_primate_rankscore,phyloP46way_placental,phyloP46way_placental_rankscore,phyloP100way_vertebrate,phyloP100way_vertebrate_rankscore,phastCons46way_primate,phastCons46way_primate_rankscore,phastCons46way_placental,phastCons46way_placental_rankscore,phastCons100way_vertebrate,phastCons100way_vertebrate_rankscore,SiPhy_29way_pi,SiPhy_29way_logOdds,SiPhy_29way_logOdds_rankscore,LRT_Omega,UniSNP_ids,ARIC5606_AA_AC,ARIC5606_AA_AF,ARIC5606_EA_AC,ARIC5606_EA_AF,clinvar_rs,clinvar_clnsig,clinvar_trait,COSMIC_ID,COSMIC_CNT
+  dbnsfp_fields: RadialSVM_score,RadialSVM_pred,LR_score,LR_pred,MutationTaster_score,MutationTaster_pred,FATHMM_score,FATHMM_pred,PROVEAN_score,PROVEAN_pred,MetaSVM_score,MetaSVM_pred,CADD_raw,CADD_phred,Reliability_index
   train_hapmap: ../variation/hapmap_3.3.vcf.gz
   train_omni: ../variation/1000G_omni2.5.vcf.gz
   train_1000g: ../variation/1000G_phase1.snps.high_confidence.vcf.gz

--- a/config/genomes/hg38-noalt-resources.yaml
+++ b/config/genomes/hg38-noalt-resources.yaml
@@ -9,6 +9,7 @@ variation:
   dbsnp: ../variation/dbsnp-147.vcf.gz
   dbnsfp: ../variation/dbNSFP.txt.gz
   dbnsfp_fields: RadialSVM_score,RadialSVM_pred,LR_score,LR_pred,MutationTaster_score,MutationTaster_pred,FATHMM_score,FATHMM_pred,PROVEAN_score,PROVEAN_pred,MetaSVM_score,MetaSVM_pred,CADD_raw,CADD_phred,Reliability_index
+  dbscsnv: ../variation/dbscSNV.txt.gz
   train_hapmap: ../variation/hapmap_3.3.vcf.gz
   train_omni: ../variation/1000G_omni2.5.vcf.gz
   train_1000g: ../variation/1000G_phase1.snps.high_confidence.vcf.gz

--- a/config/genomes/hg38-noalt-resources.yaml
+++ b/config/genomes/hg38-noalt-resources.yaml
@@ -7,6 +7,8 @@ aliases:
 
 variation:
   dbsnp: ../variation/dbsnp-147.vcf.gz
+  dbnsfp: ../variation/dbNSFP.txt.gz
+  dbnsfp_fields: LRT_score,LRT_converted_rankscore,LRT_pred,MutationTaster_score,MutationTaster_converted_rankscore,MutationTaster_pred,MutationAssessor_score,MutationAssessor_rankscore,MutationAssessor_pred,FATHMM_score,FATHMM_rankscore,FATHMM_pred,MetaSVM_score,MetaSVM_rankscore,MetaSVM_pred,MetaLR_score,MetaLR_rankscore,MetaLR_pred,Reliability_index,VEST3_score,VEST3_rankscore,PROVEAN_score,PROVEAN_converted_rankscore,PROVEAN_pred,CADD_raw,CADD_raw_rankscore,CADD_phred,GERP++_NR,GERP++_RS,GERP++_RS_rankscore,phyloP46way_primate,phyloP46way_primate_rankscore,phyloP46way_placental,phyloP46way_placental_rankscore,phyloP100way_vertebrate,phyloP100way_vertebrate_rankscore,phastCons46way_primate,phastCons46way_primate_rankscore,phastCons46way_placental,phastCons46way_placental_rankscore,phastCons100way_vertebrate,phastCons100way_vertebrate_rankscore,SiPhy_29way_pi,SiPhy_29way_logOdds,SiPhy_29way_logOdds_rankscore,LRT_Omega,UniSNP_ids,ARIC5606_AA_AC,ARIC5606_AA_AF,ARIC5606_EA_AC,ARIC5606_EA_AF,clinvar_rs,clinvar_clnsig,clinvar_trait,COSMIC_ID,COSMIC_CNT
   train_hapmap: ../variation/hapmap_3.3.vcf.gz
   train_omni: ../variation/1000G_omni2.5.vcf.gz
   train_1000g: ../variation/1000G_phase1.snps.high_confidence.vcf.gz

--- a/config/genomes/hg38-resources.yaml
+++ b/config/genomes/hg38-resources.yaml
@@ -8,8 +8,7 @@ aliases:
 variation:
   dbsnp: ../variation/dbsnp-147.vcf.gz
   dbnsfp: ../variation/dbNSFP.txt.gz
-  dbnsfp_fields: LRT_score,LRT_converted_rankscore,LRT_pred,MutationTaster_score,MutationTaster_converted_rankscore,MutationTaster_pred,MutationAssessor_score,MutationAssessor_rankscore,MutationAssessor_pred,FATHMM_score,FATHMM_rankscore,FATHMM_pred,MetaSVM_score,MetaSVM_rankscore,MetaSVM_pred,MetaLR_score,MetaLR_rankscore,MetaLR_pred,Reliability_index,VEST3_score,VEST3_rankscore,PROVEAN_score,PROVEAN_converted_rankscore,PROVEAN_pred,CADD_raw,CADD_raw_rankscore,CADD_phred,GERP++_NR,GERP++_RS,GERP++_RS_rankscore,phyloP46way_primate,phyloP46way_primate_rankscore,phyloP46way_placental,phyloP46way_placental_rankscore,phyloP100way_vertebrate,phyloP100way_vertebrate_rankscore,phastCons46way_primate,phastCons46way_primate_rankscore,phastCons46way_placental,phastCons46way_placental_rankscore,phastCons100way_vertebrate,phastCons100way_vertebrate_rankscore,SiPhy_29way_pi,SiPhy_29way_logOdds,SiPhy_29way_logOdds_rankscore,LRT_Omega,UniSNP_ids,ARIC5606_AA_AC,ARIC5606_AA_AF,ARIC5606_EA_AC,ARIC5606_EA_AF,clinvar_rs,clinvar_clnsig,clinvar_trait,COSMIC_ID,COSMIC_CNT
-  train_hapmap: ../variation/hapmap_3.3.vcf.gz
+  dbnsfp_fields: RadialSVM_score,RadialSVM_pred,LR_score,LR_pred,MutationTaster_score,MutationTaster_pred,FATHMM_score,FATHMM_pred,PROVEAN_score,PROVEAN_pred,MetaSVM_score,MetaSVM_pred,CADD_raw,CADD_phred,Reliability_index
   train_omni: ../variation/1000G_omni2.5.vcf.gz
   train_1000g: ../variation/1000G_phase1.snps.high_confidence.vcf.gz
   train_indels: ../variation/Mills_and_1000G_gold_standard.indels.vcf.gz

--- a/config/genomes/hg38-resources.yaml
+++ b/config/genomes/hg38-resources.yaml
@@ -9,7 +9,6 @@ variation:
   dbsnp: ../variation/dbsnp-147.vcf.gz
   dbnsfp: ../variation/dbNSFP.txt.gz
   dbnsfp_fields: RadialSVM_score,RadialSVM_pred,LR_score,LR_pred,MutationTaster_score,MutationTaster_pred,FATHMM_score,FATHMM_pred,PROVEAN_score,PROVEAN_pred,MetaSVM_score,MetaSVM_pred,CADD_raw,CADD_phred,Reliability_index
-  dbscsnv: ../variation/dbscSNV.txt.gz
   train_omni: ../variation/1000G_omni2.5.vcf.gz
   train_1000g: ../variation/1000G_phase1.snps.high_confidence.vcf.gz
   train_indels: ../variation/Mills_and_1000G_gold_standard.indels.vcf.gz

--- a/config/genomes/hg38-resources.yaml
+++ b/config/genomes/hg38-resources.yaml
@@ -9,6 +9,7 @@ variation:
   dbsnp: ../variation/dbsnp-147.vcf.gz
   dbnsfp: ../variation/dbNSFP.txt.gz
   dbnsfp_fields: RadialSVM_score,RadialSVM_pred,LR_score,LR_pred,MutationTaster_score,MutationTaster_pred,FATHMM_score,FATHMM_pred,PROVEAN_score,PROVEAN_pred,MetaSVM_score,MetaSVM_pred,CADD_raw,CADD_phred,Reliability_index
+  dbscsnv: ../variation/dbscSNV.txt.gz
   train_omni: ../variation/1000G_omni2.5.vcf.gz
   train_1000g: ../variation/1000G_phase1.snps.high_confidence.vcf.gz
   train_indels: ../variation/Mills_and_1000G_gold_standard.indels.vcf.gz

--- a/config/genomes/hg38-resources.yaml
+++ b/config/genomes/hg38-resources.yaml
@@ -7,6 +7,8 @@ aliases:
 
 variation:
   dbsnp: ../variation/dbsnp-147.vcf.gz
+  dbnsfp: ../variation/dbNSFP.txt.gz
+  dbnsfp_fields: LRT_score,LRT_converted_rankscore,LRT_pred,MutationTaster_score,MutationTaster_converted_rankscore,MutationTaster_pred,MutationAssessor_score,MutationAssessor_rankscore,MutationAssessor_pred,FATHMM_score,FATHMM_rankscore,FATHMM_pred,MetaSVM_score,MetaSVM_rankscore,MetaSVM_pred,MetaLR_score,MetaLR_rankscore,MetaLR_pred,Reliability_index,VEST3_score,VEST3_rankscore,PROVEAN_score,PROVEAN_converted_rankscore,PROVEAN_pred,CADD_raw,CADD_raw_rankscore,CADD_phred,GERP++_NR,GERP++_RS,GERP++_RS_rankscore,phyloP46way_primate,phyloP46way_primate_rankscore,phyloP46way_placental,phyloP46way_placental_rankscore,phyloP100way_vertebrate,phyloP100way_vertebrate_rankscore,phastCons46way_primate,phastCons46way_primate_rankscore,phastCons46way_placental,phastCons46way_placental_rankscore,phastCons100way_vertebrate,phastCons100way_vertebrate_rankscore,SiPhy_29way_pi,SiPhy_29way_logOdds,SiPhy_29way_logOdds_rankscore,LRT_Omega,UniSNP_ids,ARIC5606_AA_AC,ARIC5606_AA_AF,ARIC5606_EA_AC,ARIC5606_EA_AF,clinvar_rs,clinvar_clnsig,clinvar_trait,COSMIC_ID,COSMIC_CNT
   train_hapmap: ../variation/hapmap_3.3.vcf.gz
   train_omni: ../variation/1000G_omni2.5.vcf.gz
   train_1000g: ../variation/1000G_phase1.snps.high_confidence.vcf.gz


### PR DESCRIPTION
Hi Brad

I've tried to make some modifications to how dbNSFP was called with VEP. As I said in #1653 , It'd be nice I the users could modify which fields are used.

This PR aims to do just that. However, I haven't been able to test this (how should I go about that?).
Do you think this seems allright?

this goes together with chapmanb/cloudbiolinux#233

Thanks
M
