### PR TITLE
Coverage QC: thresholds for completeness plot and other updates

### DIFF
--- a/bcbio/bam/sambamba.py
+++ b/bcbio/bam/sambamba.py
@@ -66,21 +66,19 @@ def number_of_reads(data, bam_file, keep_dups=True):
     else:
         return _count_in_bam(data, bam_file, '', keep_dups)
 
-def number_of_mapped_reads(data, bam_file, keep_dups=True):
+def number_of_mapped_reads(data, bam_file, keep_dups=True, bed_file=None, target_name=None):
     # use idxstats if using an indexed lookup
-    if keep_dups:
+    if not bed_file and keep_dups:
         total = 0
         for c in bam.idxstats(bam_file, data):
             total += c.aligned
         return total
     else:
-        return _count_in_bam(data, bam_file, 'not unmapped', keep_dups)
+        return _count_in_bam(data, bam_file, 'not unmapped',
+            keep_dups=keep_dups, bed_file=bed_file, target_name=target_name)
 
 def number_of_properly_paired_reads(data, bam_file, keep_dups=True):
-    return _count_in_bam(data, bam_file, 'proper_pair', keep_dups)
+    return _count_in_bam(data, bam_file, 'proper_pair', keep_dups=keep_dups)
 
 def number_of_dup_reads(data, bam_file):
     return _count_in_bam(data, bam_file, 'not unmapped and duplicate')
-
-def number_mapped_reads_on_target(data, bed_file, bam_file, keep_dups=True, target_name=None):
-    return _count_in_bam(data, bam_file, 'not unmapped', keep_dups, bed_file=bed_file, target_name=target_name)

--- a/bcbio/qc/multiqc.py
+++ b/bcbio/qc/multiqc.py
@@ -130,7 +130,8 @@ def _report_summary(samples, out_dir):
         samples = _merge_metrics(samples)
 
         logger.info("summarize target information")
-        samples = _merge_target_information(samples)
+        if samples[0].get("analysis", "").lower() in ["variant", "variant2"]:
+            samples = _merge_target_information(samples)
 
         out_dir = utils.safe_makedir("coverage")
         logger.info("summarize coverage")
@@ -284,14 +285,14 @@ def _merge_target_information(samples):
     data = samples[0]
     info = {}
 
-    # Reporting in MultiQC only if the genome is the sample across samples
+    # Reporting in MultiQC only if the genome is the same across all samples
     if len(genomes) == 1:
         info["genome_info"] = {
             "name": dd.get_genome_build(data),
             "size": sum([c.size for c in ref.file_contigs(dd.get_ref_file(data), data["config"])]),
         }
 
-    # Reporting in MultiQC only if the target is the sample across samples
+    # Reporting in MultiQC only if the target is the same across all samples
     vcr_orig = None
     if len(original_variant_regions) == 1 and list(original_variant_regions)[0] is not None:
         vcr_orig = list(original_variant_regions)[0]
@@ -304,12 +305,11 @@ def _merge_target_information(samples):
         gene_num = annotate.count_genes(vcr_clean, data)
         if gene_num is not None:
             info["variants_regions_info"]["genes"] = gene_num
-
     else:
         info["variants_regions_info"] = {
             "bed": "callable regions",
         }
-    # Reporting in MultiQC only if the target is the sample across samples
+    # Reporting in MultiQC only if the target is the same across samples
     if len(coverage_beds) == 1:
         cov_bed = list(coverage_beds)[0]
         if cov_bed is not None:

--- a/bcbio/qc/multiqc.py
+++ b/bcbio/qc/multiqc.py
@@ -203,7 +203,7 @@ def _add_disambiguate(sample):
 def _fix_duplicated_rate(dt):
     """Get RNA duplicated rate if exists and replace by samtools metric"""
     if "Duplication_Rate_of_Mapped" in dt:
-        dt["Duplicates_pct"] = dt["Duplication_Rate_of_Mapped"]
+        dt["Duplicates_pct"] = 100.0 * dt["Duplication_Rate_of_Mapped"]
     return dt
 
 def _merge_metrics(samples):

--- a/bcbio/qc/qualimap.py
+++ b/bcbio/qc/qualimap.py
@@ -69,8 +69,9 @@ def run(bam_file, data, out_dir):
                 cmd += " -gff {bed6_regions}"
             bcbio_env = utils.get_bcbio_env()
             do.run(cmd.format(**locals()), "Qualimap: %s" % dd.get_sample_name(data), env=bcbio_env)
-        cmd = "sed -i 's/bam file = .*/bam file = %s.bam/' %s" % (dd.get_sample_name(data), results_file)
-        do.run(cmd, "Fix Name Qualimap for {}".format(dd.get_sample_name(data)))
+            tx_results_file = os.path.join(tx_results_dir, "genome_results.txt")
+            cmd = "sed -i 's/bam file = .*/bam file = %s.bam/' %s" % (dd.get_sample_name(data), tx_results_file)
+            do.run(cmd, "Fix Name Qualimap for {}".format(dd.get_sample_name(data)))
 
     # return _parse_qualimap_metrics(report_file, data)
     return dict()

--- a/bcbio/qc/samtools.py
+++ b/bcbio/qc/samtools.py
@@ -40,7 +40,7 @@ def _parse_samtools_stats(stats_file):
             if metric in want:
                 stat = float(stat_str.strip())
                 out[want[metric]] = stat
-    out["Mapped_reads_pct"] = 1.0 * out["Mapped"] / out["Total_reads"]
+    out["Mapped_reads_pct"] = 100.0 * out["Mapped"] / out["Total_reads"]
     out["Mapped_reads"] = out["Mapped"]  # remove after 1.0.0 release
     return out
 


### PR DESCRIPTION
Region coverage QC (completeness plot) currently checks a questionable number of depth cutoffs (1x, 5x, 10x, 20x, 40x, ... 100x, - step of 10, but skipping 30x for some reason). I find the following set of thresholds more reasonable: 1, 5, 10, 20, 50, 100, 250, 500, 1000, 5000, 10000, 50000 (high thresholds are only exposed if there is coverage at least at one sample), that what's we are used to use in TargQC, but let me know if you have another opinion.

Additionally into the text coverage files I added an extra cutoff of 80% of average coverage, which is not going to go into MultiQC, but I'm going to use it to parse in my oncology reports, hope you don't mind.

Other minor changes in this PR include:
- fix of Duplicate pct metric for RNAseq,
- expose target/genome info in MultiQC only for variant calling pipelines,  
- some refactoring of average coverage calculation.