### PR TITLE
Coverage QC fix for unpaired reads

### DIFF
--- a/bcbio/qc/multiqc.py
+++ b/bcbio/qc/multiqc.py
@@ -30,7 +30,7 @@ def summary(*samples):
     multiqc = config_utils.get_program("multiqc", samples[0]["config"])
     if not multiqc:
         logger.debug("multiqc not found. Update bcbio_nextgen.py tools to fix this issue.")
-    out_dir = utils.safe_makedir(os.path.join(work_dir, "qc", "mulitqc"))
+    out_dir = utils.safe_makedir(os.path.join(work_dir, "qc", "multiqc"))
     out_data = os.path.join(out_dir, "multiqc_data")
     out_file = os.path.join(out_dir, "multiqc_report.html")
     samples = _report_summary(samples, os.path.join(out_dir, "report"))

--- a/bcbio/qc/samtools.py
+++ b/bcbio/qc/samtools.py
@@ -27,8 +27,8 @@ def run(bam_file, data, out_dir):
 def _parse_samtools_stats(stats_file):
     out = {}
     want = {"raw total sequences":      "Total_reads",
-            "reads mapped":             "Mapped_reads_raw",
-            "reads mapped and paired":  "Mapped_reads",
+            "reads mapped":             "Mapped_reads",
+            "reads mapped and paired":  "Mapped_paired_reads",
             "reads duplicated":         "Duplicates",
             "insert size average":      "Average_insert_size"}
     with open(stats_file) as in_handle:


### PR DESCRIPTION
Addressing @sluke123's issue with missing "Avg_coverage" metric when running with single-only reads.

Also, slightly changed the stats validation in QC: if no mapped reads are found or no reads found at all in BAM, still reporting as much coverage metrics as possible. Downstream tools may depend on `project-summary.yaml` and it's good to promise that we report those metrics even in abnormal situations.