### PR TITLE
VarDict support: failing bcftools when no variants called

### DIFF
--- a/bcbio/variation/vardict.py
+++ b/bcbio/variation/vardict.py
@@ -145,13 +145,20 @@ def _run_vardict_caller(align_bams, items, ref_file, assoc_files,
                             vcfutils.write_empty_vcf(tx_tmp_file, config, samples=[sample])
                         else:
                             cmd += " > {tx_tmp_file}"
-                            do.run(cmd.format(**locals()), "Genotyping with VarDict: Inference", {})
+                            try:
+                                do.run(cmd.format(**locals()), "Genotyping with VarDict: Inference", {})
+                            except:
+                                vcfutils.write_empty_vcf(tx_tmp_file, config, samples=[sample])
+
                 else:
                     if not _is_bed_file(target):
                         vcfutils.write_empty_vcf(tx_out_file, config, samples=[sample])
                     else:
                         cmd += " > {tx_out_file}"
-                        do.run(cmd.format(**locals()), "Genotyping with VarDict: Inference", {})
+                        try:
+                            do.run(cmd.format(**locals()), "Genotyping with VarDict: Inference", {})
+                        except:
+                            vcfutils.write_empty_vcf(tx_out_file, config, samples=[sample])
             if num_bams > 1:
                 # N.B. merge_variant_files wants region in 1-based end-inclusive
                 # coordinates. Thus use bamprep.region_to_gatk

--- a/bcbio/variation/vardict.py
+++ b/bcbio/variation/vardict.py
@@ -131,7 +131,7 @@ def _run_vardict_caller(align_bams, items, ref_file, assoc_files,
                          os.path.dirname(utils.Rscript_cmd()))
                 cmd = ("{setup}{jvm_opts}{vardict} -G {ref_file} -f {freq} "
                        "-N {sample} -b {bamfile} {opts} "
-                       "| {strandbias}"
+                       "| {strandbias} "
                        "| {var2vcf} -N {sample} -E -f {freq} {var2vcf_opts} "
                        "| bcftools filter -i 'QUAL >= 0' "
                        "| {fix_ambig_ref} | {fix_ambig_alt} | {remove_dup} | {vcfstreamsort} {compress_cmd}")


### PR DESCRIPTION
In case VarDict hasn't called any variants, the bcftools call added to the commandline in commit 83ff6cce76ad772f553be65f05efcd60ef7c7e9b results in an uncaught error.

With bcftools 1.3, this is the error message: "Failed to open -: unknown file type"

The patch in this PR handles the problem, but spams the log with stack traces. Calling do.run() with log_error=False would work, but potentially hide other failures.

There must be a better way, any suggestions?