### PR TITLE
VEP: fix for genesplicer plugin

### DIFF
--- a/bcbio/variation/effects.py
+++ b/bcbio/variation/effects.py
@@ -241,10 +241,10 @@ def _get_genesplicer(data):
     https://github.com/Ensembl/VEP_plugins/blob/master/GeneSplicer.pm
     """
 
-    genesplicer_dir = os.path.dirname(os.path.realpath(config_utils.get_program("genesplicer", data["config"])))
+    genesplicer_exec = os.path.realpath(config_utils.get_program("genesplicer", data["config"]))
     genesplicer_training = tz.get_in(("genome_resources", "variation", "genesplicer"), data)
     if genesplicer_dir and os.path.exists(genesplicer_dir) and genesplicer_training and os.path.exists(genesplicer_training) :
-        return ["--plugin", "GeneSplicer,%s,%s" % (genesplicer_dir,genesplicer_training)]
+        return ["--plugin", "GeneSplicer,%s,%s" % (genesplicer_exec,genesplicer_training)]
     else:
         return []
 

--- a/bcbio/variation/effects.py
+++ b/bcbio/variation/effects.py
@@ -243,7 +243,7 @@ def _get_genesplicer(data):
 
     genesplicer_exec = os.path.realpath(config_utils.get_program("genesplicer", data["config"]))
     genesplicer_training = tz.get_in(("genome_resources", "variation", "genesplicer"), data)
-    if genesplicer_dir and os.path.exists(genesplicer_dir) and genesplicer_training and os.path.exists(genesplicer_training) :
+    if genesplicer_exec and os.path.exists(genesplicer_exec) and genesplicer_training and os.path.exists(genesplicer_training) :
         return ["--plugin", "GeneSplicer,%s,%s" % (genesplicer_exec,genesplicer_training)]
     else:
         return []


### PR DESCRIPTION
Hi Brad,

Apparently, the genesplicer function called the executable dir, instead of the executable itself. An oversight which didn't come out during my testing, since the genesplicer resource seemed unavailable.

Anyways, this should fix it.

Thanks
M