### PR TITLE
MultiQC: upload file list into final

### DIFF
--- a/bcbio/qc/multiqc.py
+++ b/bcbio/qc/multiqc.py
@@ -68,7 +68,7 @@ def summary(*samples):
                 if "summary" not in data:
                     data["summary"] = {}
                 data["summary"]["multiqc"] = {"base": out_file, "secondary": data_files}
-                file_list_final = _save_uploaded_file_list(samples, file_list, out_dir)  # keep this line after out.append([data])
+                file_list_final = _save_uploaded_file_list(samples, file_list, out_dir)
                 if file_list_final:
                     data["summary"]["multiqc"]["secondary"].append(file_list_final)
         out.append([data])
@@ -88,7 +88,10 @@ def _save_uploaded_file_list(samples, file_list_work, out_dir):
     upload_paths = []
     for path in paths:
         if path in upload_path_mapping:
-            upload_paths.append(upload_path_mapping[path])
+            upload_path = upload_path_mapping[path]
+            upload_base = samples[0]["upload"]["dir"]
+            upload_relpath = os.path.relpath(upload_path, upload_base)
+            upload_paths.append(upload_relpath)
     if not upload_paths:
         return None
     with open(file_list_final, "w") as f:

--- a/bcbio/qc/multiqc.py
+++ b/bcbio/qc/multiqc.py
@@ -22,6 +22,7 @@ from bcbio.pipeline import config_utils
 from bcbio.bam import ref
 from bcbio.structural import annotate
 from bcbio.variation import bedutils
+from bcbio.upload import get_all_upload_paths_from_sample
 
 def summary(*samples):
     """Summarize all quality metrics together"""
@@ -33,6 +34,7 @@ def summary(*samples):
     out_dir = utils.safe_makedir(os.path.join(work_dir, "qc", "multiqc"))
     out_data = os.path.join(out_dir, "multiqc_data")
     out_file = os.path.join(out_dir, "multiqc_report.html")
+    file_list = os.path.join(out_dir, "list_files.txt")
     samples = _report_summary(samples, os.path.join(out_dir, "report"))
     if not utils.file_exists(out_file):
         with tx_tmpdir(samples[0], work_dir) as tx_out:
@@ -41,7 +43,7 @@ def summary(*samples):
             if _one_exists(in_files):
                 with utils.chdir(out_dir):
                     _create_config_file(out_dir, samples)
-                    input_list_file = _create_list_file(in_files, out_dir)
+                    input_list_file = _create_list_file(in_files, file_list)
                     if dd.get_tmp_dir(samples[0]):
                         export_tmp = "export TMPDIR=%s &&" % dd.get_tmp_dir(samples[0])
                     else:
@@ -60,12 +62,39 @@ def summary(*samples):
                 data_files += glob.glob(os.path.join(out_dir, "report", "*", "*.bed"))
                 data_files += glob.glob(os.path.join(out_dir, "report", "*", "*.txt"))
                 data_files += glob.glob(os.path.join(out_dir, "report", "*", "*.tsv"))
+                data_files += glob.glob(os.path.join(out_dir, "report", "*", "*.yaml"))
                 data_files += glob.glob(os.path.join(out_dir, "report", "*.R*"))
+                data_files.append(file_list)
                 if "summary" not in data:
                     data["summary"] = {}
                 data["summary"]["multiqc"] = {"base": out_file, "secondary": data_files}
+                file_list_final = _save_uploaded_file_list(samples, file_list, out_dir)  # keep this line after out.append([data])
+                if file_list_final:
+                    data["summary"]["multiqc"]["secondary"].append(file_list_final)
         out.append([data])
     return out
+
+def _save_uploaded_file_list(samples, file_list_work, out_dir):
+    if not utils.file_exists(file_list_work):
+        return None
+    file_list_final = os.path.join(out_dir, "list_files_final.txt")
+    upload_path_mapping = dict()
+    for sample in samples:
+        upload_path_mapping.update(get_all_upload_paths_from_sample(sample))
+    if not upload_path_mapping:
+        return None
+    with open(file_list_work) as f:
+        paths = [l.strip() for l in f.readlines() if os.path.exists(l.strip())]
+    upload_paths = []
+    for path in paths:
+        if path in upload_path_mapping:
+            upload_paths.append(upload_path_mapping[path])
+    if not upload_paths:
+        return None
+    with open(file_list_final, "w") as f:
+        for path in upload_paths:
+            f.write(path + '\n')
+    return file_list_final
 
 def _one_exists(input_files):
     """
@@ -129,10 +158,10 @@ def _group_by_samplename(samples):
         out[(dd.get_sample_name(data), dd.get_align_bam(data))].append(data)
     return [xs[0] for xs in out.values()]
 
-def _create_list_file(dirs, out_dir):
-    out_file = os.path.join(out_dir, "list_files.txt")
+def _create_list_file(paths, out_file):
     with open(out_file, "w") as f:
-        f.write('\n'.join(dirs))
+        for path in paths:
+            f.write(path + '\n')
     return out_file
 
 def _create_config_file(out_dir, samples):
@@ -232,7 +261,7 @@ def _report_summary(samples, out_dir):
             # messages. We need to generalize coverage reporting and re-include.
             # try:
             #     do.run(cmd, "Prepare coverage summary", log_error=False)
-# except subprocess.CalledProcessError as msg:
+            # except subprocess.CalledProcessError as msg:
             #     logger.info("Skipping generation of coverage report: %s" % (str(msg)))
             if utils.file_exists("report-ready.html"):
                 shutil.move("report-ready.html", out_report)

--- a/bcbio/upload/__init__.py
+++ b/bcbio/upload/__init__.py
@@ -33,6 +33,21 @@ def from_sample(sample):
             approach.update_file(finfo, sample, upload_config)
     return [[sample]]
 
+def get_all_upload_paths_from_sample(sample):
+    upload_path_mapping = dict()
+    upload_config = sample.get("upload")
+    if upload_config:
+        method = upload_config.get("method", "filesystem")
+        if method == "filesystem":
+            approach = _approaches[method]
+            for finfo in _get_files_project(sample, upload_config):
+                path = approach.get_upload_path(finfo, None, upload_config)
+                upload_path_mapping[finfo["path"]] = path
+            for finfo in _get_files(sample):
+                path = approach.get_upload_path(finfo, sample, upload_config)
+                upload_path_mapping[finfo["path"]] = path
+    return upload_path_mapping
+
 # ## File information from sample
 
 def _get_files(sample):

--- a/bcbio/upload/filesystem.py
+++ b/bcbio/upload/filesystem.py
@@ -7,16 +7,60 @@ from bcbio import utils
 from bcbio.log import logger
 from bcbio.upload import shared
 
-def copy_finfo(finfo, storage_dir, pass_uptodate=False):
-    """Copy a file into the output storage directory.
+def update_file(finfo, sample_info, config, pass_uptodate=False):
+    """Update the file in local filesystem storage.
     """
+    storage_dir = utils.safe_makedir(_get_storage_dir(finfo, config))
+    
+    if finfo.get("type") == "directory":
+        return _copy_finfo_directory(finfo, storage_dir)
+    else:
+        return _copy_finfo(finfo, storage_dir, pass_uptodate=pass_uptodate)
+
+def get_upload_path(finfo, sample_info, config):
+    """"Dry" update the file: only return the upload path
+    """
+    try:
+        storage_dir = _get_storage_dir(finfo, config)
+    except ValueError:
+        return None
+    
+    if finfo.get("type") == "directory":
+        return _get_dir_upload_path(finfo, storage_dir)
+    else:
+        return _get_file_upload_path(finfo, storage_dir)
+
+def _get_storage_dir(finfo, config):
+    # skip if we have no directory to upload to
+    if "dir" not in config:
+        raise ValueError("Expect `dir` in upload specification: "
+                         "http://bcbio-nextgen.readthedocs.io/en/latest/contents/configuration.html#upload")
+    if "sample" in finfo:
+        storage_dir = os.path.join(config["dir"], finfo["sample"])
+    elif "run" in finfo:
+        storage_dir = os.path.join(config["dir"], finfo["run"])
+    else:
+        raise ValueError("Unexpected input file information: %s" % finfo)
+    if "dir" in finfo:
+        storage_dir = os.path.join(storage_dir, finfo["dir"])
+    return storage_dir
+
+def _get_file_upload_path(finfo, storage_dir):
     if "sample" in finfo and "ext" in finfo and "type" in finfo:
         out_file = os.path.join(storage_dir, "%s-%s%s%s" % (finfo["sample"], finfo["ext"],
                                                             "-" if (".txt" in finfo["type"]) else ".",
                                                             finfo["type"]))
     else:
         out_file = os.path.join(storage_dir, os.path.basename(finfo["path"]))
-    out_file = os.path.abspath(out_file)
+    return os.path.abspath(out_file)
+    
+def _get_dir_upload_path(finfo, storage_dir):
+    return os.path.abspath(os.path.join(storage_dir, finfo["ext"]))
+
+def _copy_finfo(finfo, storage_dir, pass_uptodate=False):
+    """Copy a file into the output storage directory.
+    """
+    out_file = _get_file_upload_path(finfo, storage_dir)
     if not shared.up_to_date(out_file, finfo):
         logger.info("Storing in local filesystem: %s" % out_file)
         shutil.copy(finfo["path"], out_file)
@@ -24,10 +68,9 @@ def copy_finfo(finfo, storage_dir, pass_uptodate=False):
     if pass_uptodate:
         return out_file
 
-def copy_finfo_directory(finfo, storage_dir):
+def _copy_finfo_directory(finfo, out_dir):
     """Copy a directory into the final output directory.
     """
-    out_dir = os.path.abspath(os.path.join(storage_dir, finfo["ext"]))
     if not shared.up_to_date(out_dir, finfo):
         logger.info("Storing directory in local filesystem: %s" % out_dir)
         if os.path.exists(out_dir):
@@ -38,25 +81,3 @@ def copy_finfo_directory(finfo, storage_dir):
                 shutil.rmtree(os.path.join(out_dir, tmpdir))
         os.utime(out_dir, None)
     return out_dir
-
-def update_file(finfo, sample_info, config, pass_uptodate=False):
-    """Update the file in local filesystem storage.
-    """
-    # skip if we have no directory to upload to
-    if "dir" not in config:
-        raise ValueError("Expect `dir` in upload specification: "
-                         "http://bcbio-nextgen.readthedocs.io/en/latest/contents/configuration.html#upload")
-    if "sample" in finfo:
-        storage_dir = utils.safe_makedir(os.path.join(config["dir"], finfo["sample"]))
-    elif "run" in finfo:
-        storage_dir = utils.safe_makedir(os.path.join(config["dir"], finfo["run"]))
-    else:
-        raise ValueError("Unexpected input file information: %s" % finfo)
-
-    if "dir" in finfo:
-        storage_dir = utils.safe_makedir(os.path.join(storage_dir, finfo["dir"]))
-
-    if finfo.get("type") == "directory":
-        return copy_finfo_directory(finfo, storage_dir)
-    else:
-        return copy_finfo(finfo, storage_dir, pass_uptodate=pass_uptodate)


### PR DESCRIPTION
1. Refactored the upload code a little to separate the functions that only return paths from the functions that actually upload files (e.g. `update_file` vs. `get_upload_path`)
2. Added a function that returns all paths that would to be uploaded for current run.
3. Use that function to generate `list_files_final.txt` for multiqc (partly resolves https://github.com/chapmanb/bcbio-nextgen/issues/1708)

Unfortunately that works only for the filesystem now. I don't have an infrastructure to test similar changes for other upload methods, so I hesitated with this PR. But I figured that might be a good idea to share my changes anyway so you might have suggestions and ideas, and then I or Brad or Lorena could move forward with finalising this, or rewriting, or continuing towards #1808