### PR TITLE
Fix coverage QC metrics for WGS

### DIFF
--- a/bcbio/pipeline/qcsummary.py
+++ b/bcbio/pipeline/qcsummary.py
@@ -136,12 +136,12 @@ def _run_qc_tools(bam_file, data):
         out = qc_fn(bam_file, data, cur_qc_dir)
         qc_files = None
         if out and isinstance(out, dict):
-            if "base" in out:
-                if "metrics" in out:
-                    metrics.update(out.pop("metrics"))
-                qc_files = out
+            if "metrics" in out:
+                metrics.update(out.pop("metrics"))
             else:
                 metrics.update(out)
+            if "base" in out:
+                qc_files = out
         elif out and isinstance(out, basestring) and os.path.exists(out):
             qc_files = {"base": out, "secondary": []}
         if not qc_files:

--- a/bcbio/qc/multiqc.py
+++ b/bcbio/qc/multiqc.py
@@ -147,7 +147,8 @@ def _get_input_files(samples, base_dir, tx_out_dir):
     # Back compatible -- to migrate to explicit specifications in input YAML
     staged_files += ["trimmed", "htseq-count/*summary"]
     # Add in created target_info file
-    staged_files += [os.path.join(base_dir, "report", "metrics", "target_info.yaml")]
+    if os.path.isfile(os.path.join(base_dir, "report", "metrics", "target_info.yaml")):
+        staged_files += [os.path.join(base_dir, "report", "metrics", "target_info.yaml")]
     return sorted(list(set(staged_files)))
 
 def _in_temp_directory(f):


### PR DESCRIPTION
This PR fixes the issue of WGS runs missing the QC metrics. 

The problem is that metrics are only added if `"base"` is in the `out` dict, whereas `"base"` is added only if either `goleft indexcov` or detailed coverage is run, and both are skipped for WGS.

Plus unrelated minor fix in multiqc.