### PR TITLE
More VarScan improvements

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,8 @@
 ## 1.0.3 (in progress)
 
+- Several updates to the VarScan support: honor options specified in the
+  resource config section; honor min_allele_frac option and set --strand-filter
+  flag in the single-sample case; general cleanups. Thanks to Christian Brueffer.
 - Fix FreeBayes somatic and multi-sample calling order to be consistent between
   chromosome region runs. Thanks to Ho Danliang.
 - Update validation plots to support matplotlib 2.0.

--- a/bcbio/variation/varscan.py
+++ b/bcbio/variation/varscan.py
@@ -51,7 +51,7 @@ def _get_jvm_opts(config, tmp_dir):
 def _varscan_options_from_config(config):
     """Retrieve additional options for VarScan from the configuration.
     """
-    opts = ["--min-coverage 5", "--p-value 0.98"]
+    opts = ["--min-coverage 5", "--p-value 0.98", "--strand-filter 1"]
     resources = config_utils.get_resources("varscan", config)
     if resources.get("options"):
         opts += resources["options"]
@@ -135,7 +135,7 @@ def _varscan_paired(align_bams, ref_file, items, target_regions, out_file):
                                " <({normal_mpileup_cl} | {remove_zerocoverage}) "
                                "<({tumor_mpileup_cl} | {remove_zerocoverage}) "
                                "--output-snp {tx_snp} --output-indel {tx_indel} "
-                               " --output-vcf --strand-filter 1 {opts} ")
+                               " --output-vcf {opts} ")
                 # add minimum AF
                 min_af = float(utils.get_in(paired.tumor_config, ("algorithm",
                                                                   "min_allele_fraction"), 10)) / 100.0

--- a/bcbio/variation/varscan.py
+++ b/bcbio/variation/varscan.py
@@ -51,7 +51,7 @@ def _get_jvm_opts(config, tmp_dir):
 def _varscan_options_from_config(config):
     """Retrieve additional options for VarScan from the configuration.
     """
-    opts = []
+    opts = ["--min-coverage 5", "--p-value 0.98"]
     resources = config_utils.get_resources("varscan", config)
     if resources.get("options"):
         opts += resources["options"]
@@ -135,8 +135,7 @@ def _varscan_paired(align_bams, ref_file, items, target_regions, out_file):
                                " <({normal_mpileup_cl} | {remove_zerocoverage}) "
                                "<({tumor_mpileup_cl} | {remove_zerocoverage}) "
                                "--output-snp {tx_snp} --output-indel {tx_indel} "
-                               " --output-vcf --min-coverage 5 --p-value 0.98 {opts} "
-                               "--strand-filter 1 ")
+                               " --output-vcf --strand-filter 1 {opts} ")
                 # add minimum AF
                 min_af = float(utils.get_in(paired.tumor_config, ("algorithm",
                                                                   "min_allele_fraction"), 10)) / 100.0
@@ -311,8 +310,8 @@ def _varscan_work(align_bams, ref_file, items, target_regions, out_file):
         py_cl = os.path.join(os.path.dirname(sys.executable), "py")
         export = utils.local_path_export()
         cmd = ("{export} {mpileup} | {remove_zerocoverage} | "
-                "ifne varscan {jvm_opts} mpileup2cns --min-coverage 5 --p-value 0.98 {opts} "
-                "  --vcf-sample-list {sample_list} --min-var-freq {min_af} --output-vcf --variants | "
+                "ifne varscan {jvm_opts} mpileup2cns {opts} "
+                "--vcf-sample-list {sample_list} --min-var-freq {min_af} --output-vcf --variants | "
                "{py_cl} -x 'bcbio.variation.varscan.fix_varscan_output(x)' | "
                 "{fix_ambig_ref} | {fix_ambig_alt} | ifne vcfuniqalleles > {out_file}")
         do.run(cmd.format(**locals()), "Varscan", None,

--- a/bcbio/variation/varscan.py
+++ b/bcbio/variation/varscan.py
@@ -132,10 +132,10 @@ def _varscan_paired(align_bams, ref_file, items, target_regions, out_file):
                 remove_zerocoverage = r"{ ifne grep -v -P '\t0\t\t$' || true; }"
                 export = utils.local_path_export()
                 varscan_cmd = ("{export} varscan {jvm_opts} somatic "
-                               " <({normal_mpileup_cl} | {remove_zerocoverage}) "
+                               "<({normal_mpileup_cl} | {remove_zerocoverage}) "
                                "<({tumor_mpileup_cl} | {remove_zerocoverage}) "
                                "--output-snp {tx_snp} --output-indel {tx_indel} "
-                               " --output-vcf {opts} ")
+                               "--output-vcf {opts} ")
                 # add minimum AF
                 min_af = float(utils.get_in(paired.tumor_config, ("algorithm",
                                                                   "min_allele_fraction"), 10)) / 100.0
@@ -310,10 +310,10 @@ def _varscan_work(align_bams, ref_file, items, target_regions, out_file):
         py_cl = os.path.join(os.path.dirname(sys.executable), "py")
         export = utils.local_path_export()
         cmd = ("{export} {mpileup} | {remove_zerocoverage} | "
-                "ifne varscan {jvm_opts} mpileup2cns {opts} "
-                "--vcf-sample-list {sample_list} --min-var-freq {min_af} --output-vcf --variants | "
+               "ifne varscan {jvm_opts} mpileup2cns {opts} "
+               "--vcf-sample-list {sample_list} --min-var-freq {min_af} --output-vcf --variants | "
                "{py_cl} -x 'bcbio.variation.varscan.fix_varscan_output(x)' | "
-                "{fix_ambig_ref} | {fix_ambig_alt} | ifne vcfuniqalleles > {out_file}")
+               "{fix_ambig_ref} | {fix_ambig_alt} | ifne vcfuniqalleles > {out_file}")
         do.run(cmd.format(**locals()), "Varscan", None,
                 [do.file_exists(out_file)])
     os.remove(sample_list)


### PR DESCRIPTION
- Apply options specified in the VarScan resources config section
- Centrally apply some options common to paired/single sample calling
- Add --strand-filter in the single sample case to match paired calling
- general cleanup.