### PR TITLE
Allow fractional memory specifications (e.g., 7.6G) in convert_to_bytes()

### DIFF
--- a/bcbio/pipeline/config_utils.py
+++ b/bcbio/pipeline/config_utils.py
@@ -333,11 +333,11 @@ def convert_to_bytes(mem_str):
     """Convert a memory specification, potentially with M or G, into bytes.
     """
     if str(mem_str)[-1].upper().endswith("G"):
-        return int(mem_str[:-1]) * 1024 * 1024
+        return int(round(float(mem_str[:-1]) * 1024 * 1024))
     elif str(mem_str)[-1].upper().endswith("M"):
-        return int(mem_str[:-1]) * 1024
+        return int(round(float(mem_str[:-1]) * 1024))
     else:
-        return int(mem_str)
+        return int(round(float(mem_str)))
 
 def adjust_cores_to_mb_target(target_mb, mem_str, cores):
     """Scale core usage to match a Mb/core target.


### PR DESCRIPTION
Fractional memory specifications work in all other cases I've seen. With this they also work in e.g. the BAM to FASTQ code path.