### PR TITLE
In the RNA-seq pipeline skip qualimap_rnaseq if qualimap was turned off.

### DIFF
--- a/bcbio/pipeline/qcsummary.py
+++ b/bcbio/pipeline/qcsummary.py
@@ -84,10 +84,11 @@ def get_qc_tools(data):
             for tool in ["qualimap", "qualimap_full"]]):
         to_run.append("qualimap")
     if analysis.startswith("rna-seq"):
-        if gtf.is_qualimap_compatible(dd.get_gtf_file(data)):
-            to_run.append("qualimap_rnaseq")
-        else:
-            logger.debug("GTF not compatible with Qualimap, skipping.")
+        if "qualimap" not in dd.get_tools_off(data):
+            if gtf.is_qualimap_compatible(dd.get_gtf_file(data)):
+                to_run.append("qualimap_rnaseq")
+            else:
+                logger.debug("GTF not compatible with Qualimap, skipping.")
     if analysis.startswith("smallrna-seq"):
         to_run.append("small-rna")
     if not analysis.startswith("smallrna-seq"):


### PR DESCRIPTION
This allows to prevent gtf.is_qualimap_compatible() from being run. When executing several bcbio-nextgen RNA-seq runs in parallel, they all call gtf.is_qualimap_compatible(), resulting in crashes because every process tries to open the GTF DB in get_gtf_db().

Arguably we should find a solution for the concurrent DB access problem, but this works fine for now.