### PR TITLE
Handle empty resource sections instead of crashing.

### DIFF
--- a/bcbio/pipeline/main.py
+++ b/bcbio/pipeline/main.py
@@ -430,8 +430,9 @@ def _pair_samples_with_pipelines(run_info_yaml, config):
         for prog, pkvs in resources.items():
             if prog not in usample["resources"]:
                 usample["resources"][prog] = {}
-            for key, val in pkvs.items():
-                usample["resources"][prog][key] = val
+            if pkvs is not None:
+                for key, val in pkvs.items():
+                    usample["resources"][prog][key] = val
         config = config_utils.update_w_custom(config, usample)
         sample["resources"] = {}
         ready_samples.append(sample)

--- a/bcbio/pipeline/run_info.py
+++ b/bcbio/pipeline/run_info.py
@@ -795,8 +795,9 @@ def _run_info_from_yaml(dirs, run_info_yaml, config, sample_names=None, integrat
         for prog, pkvs in resources.items():
             if prog not in item["resources"]:
                 item["resources"][prog] = {}
-            for key, val in pkvs.items():
-                item["resources"][prog][key] = val
+            if pkvs is not None:
+                for key, val in pkvs.items():
+                    item["resources"][prog][key] = val
         for iname, ivals in integrations.items():
             if ivals:
                 if iname not in item:


### PR DESCRIPTION
Previously having the following snippet in the config would lead to a crash:

```
resources:
  default:
    # no specifications here
```