### PR TITLE
Fix Seq2C for paired samples

### DIFF
--- a/bcbio/structural/cnvkit.py
+++ b/bcbio/structural/cnvkit.py
@@ -270,10 +270,10 @@ def _cnvkit_fix_base(cnns, background_cnn, items, ext=""):
     target_cnn = [x["file"] for x in cnns if x["cnntype"] == "target"][0]
     antitarget_cnn = [x["file"] for x in cnns if x["cnntype"] == "antitarget"][0]
     data = [x for x in items if dd.get_sample_name(x) == cnns[0]["sample"]][0]
-    common_refix = os.path.commonprefix([target_cnn, antitarget_cnn])
-    if common_refix.endswith("."):
-        common_refix = common_refix[:-1]
-    out_file = "%s%s.cnr" % (common_refix, ext)
+    common_prefix = os.path.commonprefix([target_cnn, antitarget_cnn])
+    if common_prefix.endswith("."):
+        common_prefix = common_prefix[:-1]
+    out_file = "%s%s.cnr" % (common_prefix, ext)
     if not utils.file_exists(out_file):
         with file_transaction(data, out_file) as tx_out_file:
             cmd = [_get_cmd(), "fix", "-o", tx_out_file, target_cnn, antitarget_cnn, background_cnn]

--- a/bcbio/structural/seq2c.py
+++ b/bcbio/structural/seq2c.py
@@ -67,7 +67,7 @@ def run(items):
 
     normal_names = [dd.get_sample_name(x) for x in items if population.get_affected_status(x) == 1]
     seq2c_calls_file = _call_cnv(items, work_dir, read_mapping_file, coverage_file, normal_names)
-    items = _split_cnv(items, seq2c_calls_file)
+    _split_cnv(items, seq2c_calls_file)
     return items
 
 def prep_seq2c_bed(data):
@@ -141,7 +141,6 @@ def _call_cnv(items, work_dir, read_mapping_file, coverage_file, control_sample_
     return output_fpath
 
 def _split_cnv(items, calls_fpath):
-    out_items = []
     for item in items:
         if get_paired_phenotype(item) == "normal":
             continue
@@ -158,8 +157,6 @@ def _split_cnv(items, calls_fpath):
                             out.write(l)
         item["sv"][0]["calls"] = out_fname
         item["sv"][0]["vrn_file"] = to_vcf(out_fname, item)
-        out_items.append(item)
-    return out_items
 
 VCF_HEADER = """##fileformat=VCFv4.1
 ##INFO=<ID=END,Number=1,Type=Integer,Description="End position of the variant described in this record">


### PR DESCRIPTION
When running on tumor/normal pairs, Seq2C's cohort calling function returns a cut sample list containing only tumors, leading to skipping normals in downstream steps, ending with no normals in`final`. This PR fixes that.