### PR TITLE
Seq2C coverage file is not batch-level

### DIFF
--- a/bcbio/upload/__init__.py
+++ b/bcbio/upload/__init__.py
@@ -226,7 +226,7 @@ def _maybe_add_sv(algorithm, sample, out):
         batch = _get_batch_name(sample)
         for svcall in sample["sv"]:
             if svcall.get("variantcaller") == "seq2c":
-                out.extend(_get_variant_file(svcall, ("coverage",), suffix="-coverage", sample=batch))
+                out.extend(_get_variant_file(svcall, ("coverage",), suffix="-coverage"))
                 out.extend(_get_variant_file(svcall, ("calls",), sample=batch))
             for key in ["vrn_file", "cnr", "cns", "seg", "gainloss",
                         "segmetrics", "vrn_bed", "vrn_bedpe"]:


### PR DESCRIPTION
Hi Brad, another minor fix for Seq2C. The `*-coverage` files it reports are not batch-level, but sample-level, so they should probably have the sample names in their files names rather than batch names. Basically that's not a big deal to just keep it as batch (it breaks postproc but easily fixable), but I figure it would be nice to correct it in bcbio.