### PR TITLE
Aggregate MultiQC configuration in one place 

### DIFF
--- a/bcbio/qc/multiqc.py
+++ b/bcbio/qc/multiqc.py
@@ -181,13 +181,8 @@ def _create_config_file(out_dir, samples):
     Future entry point for providing top level configuration of output reports.
     """
     out_file = os.path.join(out_dir, "multiqc_config.yaml")
-    out = {"table_columns_visible":
-           {"SnpEff": {"Change_rate": False,
-                       "Ts_Tv_ratio": False,
-                       "Number_of_variants_before_filter": False},
-            "samtools": {"error_rate": False}},
-           "module_order": ["bcbio", "samtools", "goleft_indexcov", "bcftools", "picard", "qualimap",
-                            "snpeff", "fastqc"]}
+    out = {"table_columns_visible": dict()}
+
     # Avoid duplicated bcbio columns with qualimap
     if any(("qualimap" in dd.get_tools_on(d) or "qualimap_full" in dd.get_tools_on(d))
            for d in samples):


### PR DESCRIPTION
Moving `table_columns_visible` and `module_order` settings into MultiQC_bcbio: https://github.com/MultiQC/MultiQC_bcbio/pull/14. Except for those that are set dynamically (e.g. when `qualimap` is on).

Also, `"samtools": {"error_rate": False}}` doesn't work - should be `"Samtools Stats": {"error_rate": False}}`.