### PR TITLE
Add Preseq tool for complexity prediction.

### DIFF
--- a/bcbio/cwl/defs.py
+++ b/bcbio/cwl/defs.py
@@ -327,7 +327,7 @@ def variant(samples):
                             cwlout(["summary", "metrics"], "string"),
                             cwlout("inherit")])],
             "bcbio-vc", ["bcftools", "bedtools", "fastqc", "goleft", "picard", "pythonpy",
-                         "qsignature", "qualimap", "sambamba", "samtools"]),
+                         "qsignature", "qualimap", "sambamba", "samtools", "preseq"]),
           s("multiqc_summary", "multi-combined",
             [["qcout_rec"]],
             [cwlout(["summary", "multiqc"], ["File", "null"])],

--- a/bcbio/pipeline/main.py
+++ b/bcbio/pipeline/main.py
@@ -145,7 +145,7 @@ def variant2pipeline(config, run_info_yaml, parallel, dirs, samples):
     with prun.start(_wres(parallel, ["gatk", "gatk-vqsr", "snpeff", "bcbio_variation",
                                      "gemini", "samtools", "fastqc", "sambamba",
                                      "bcbio-variation-recall", "qsignature",
-                                     "svcaller"]),
+                                     "svcaller", "preseq"]),
                     samples, config, dirs, "multicore2",
                     multiplier=structural.parallel_multiplier(samples)) as run_parallel:
         with profile.report("joint squaring off/backfilling", dirs):
@@ -213,7 +213,7 @@ def standardpipeline(config, run_info_yaml, parallel, dirs, samples):
             samples = run_parallel("combine_sample_regions", [samples])
             samples = region.clean_sample_data(samples)
     ## Quality control
-    with prun.start(_wres(parallel, ["fastqc", "qsignature", "kraken", "gatk", "samtools"]),
+    with prun.start(_wres(parallel, ["fastqc", "qsignature", "kraken", "gatk", "samtools", "preseq"]),
                     samples, config, dirs, "multicore2") as run_parallel:
         with profile.report("quality control", dirs):
             samples = qcsummary.generate_parallel(samples, run_parallel)
@@ -252,7 +252,7 @@ def rnaseqpipeline(config, run_info_yaml, parallel, dirs, samples):
             samples = rnaseq.rnaseq_variant_calling(samples, run_parallel)
 
     with prun.start(_wres(parallel, ["samtools", "fastqc", "qualimap",
-                                        "kraken", "gatk"], ensure_mem={"qualimap": 4}),
+                                     "kraken", "gatk", "preseq"], ensure_mem={"qualimap": 4}),
                     samples, config, dirs, "qc") as run_parallel:
         with profile.report("quality control", dirs):
             samples = qcsummary.generate_parallel(samples, run_parallel)

--- a/bcbio/pipeline/qcsummary.py
+++ b/bcbio/pipeline/qcsummary.py
@@ -103,6 +103,8 @@ def get_qc_tools(data):
             to_run += ["damage"]
     if dd.get_umi_consensus(data):
         to_run += ["umi"]
+    if tz.get_in(["config", "algorithm", "preseq"], data):
+        to_run.append("preseq")
     return to_run
 
 def _run_qc_tools(bam_file, data):
@@ -114,7 +116,7 @@ def _run_qc_tools(bam_file, data):
         :returns: dict with output of different tools
     """
     from bcbio.qc import (coverage, damage, fastqc, kraken, qsignature, qualimap,
-                          samtools, picard, srna, umi, variant, viral)
+                          samtools, picard, srna, umi, variant, viral, preseq)
     tools = {"fastqc": fastqc.run,
              "small-rna": srna.run,
              "samtools": samtools.run,
@@ -127,7 +129,9 @@ def _run_qc_tools(bam_file, data):
              "kraken": kraken.run,
              "picard": picard.run,
              "umi": umi.run,
-             "viral": viral.run}
+             "viral": viral.run,
+             "preseq": preseq.run,
+             }
     qc_dir = utils.safe_makedir(os.path.join(data["dirs"]["work"], "qc", data["description"]))
     metrics = {}
     qc_out = {}

--- a/bcbio/pipeline/run_info.py
+++ b/bcbio/pipeline/run_info.py
@@ -455,7 +455,7 @@ ALGORITHM_KEYS = set(["platform", "aligner", "bam_clean", "bam_sort",
                       "archive", "tools_off", "tools_on", "transcript_assembler",
                       "mixup_check", "expression_caller", "qc", "positional_umi",
                       "cellular_barcode_correction",
-                      "singlecell_quantifier" , "spikein_fasta"] +
+                      "singlecell_quantifier", "spikein_fasta", "preseq",] +
                      # development
                      ["cwl_reporting"] +
                      # back compatibility
@@ -463,7 +463,7 @@ ALGORITHM_KEYS = set(["platform", "aligner", "bam_clean", "bam_sort",
 ALG_ALLOW_BOOLEANS = set(["merge_bamprep", "mark_duplicates", "remove_lcr",
                           "clinical_reporting", "transcriptome_align",
                           "fusion_mode", "assemble_transcripts", "trim_reads",
-                          "recalibrate", "realign", "cwl_reporting", "save_diskspace"])
+                          "recalibrate", "realign", "cwl_reporting", "save_diskspace", "preseq"])
 ALG_ALLOW_FALSE = set(["aligner", "align_split_size", "bam_clean", "bam_sort",
                        "effects", "phasing", "mixup_check", "indelcaller",
                        "variantcaller", "positional_umi", "maxcov_downsample"])

--- a/bcbio/provenance/programs.py
+++ b/bcbio/provenance/programs.py
@@ -31,6 +31,7 @@ _cl_progs = [{"cmd": "bamtofastq", "name": "biobambam",
              {"cmd": "novoalign", "stdout_flag": "Novoalign"},
              {"cmd": "samtools", "stdout_flag": "Version:"},
              {"cmd": "qualimap", "args": "-h", "stdout_flag": "QualiMap"},
+             {"cmd": "preseq", "stdout_flag": "preseq"},
              {"cmd": "vcflib", "has_cl_version": False},
              {"cmd": "featurecounts", "args": "-v", "stdout_flag": "featureCounts"}]
 _manifest_progs = ["bcbio-variation", "bioconductor-bubbletree", "cufflinks",

--- a/bcbio/qc/preseq.py
+++ b/bcbio/qc/preseq.py
@@ -1,0 +1,115 @@
+"""Run Preseq, a tool that estimates the complexity of a library.
+http://smithlabresearch.org/software/preseq/
+
+Uses the command `lc_extrap` that predicts the yield for future experiment
+by showing how many additional unique reads are sequenced for increasing
+total read count.
+
+"""
+import os
+import math
+import pybedtools
+import toolz as tz
+
+from bcbio import utils
+from bcbio.distributed.transaction import file_transaction
+from bcbio.log import logger
+from bcbio.provenance import do
+from bcbio.pipeline import datadict as dd
+from bcbio.pipeline import config_utils
+from bcbio.bam import ref, sambamba
+from bcbio.variation import coverage as cov
+from bcbio.qc import samtools
+
+
+def run(bam_file, data, out_dir):
+    out = {}
+    if not tz.get_in(["config", "algorithm", "preseq"], data):
+        return out
+
+    samtools_stats_dir = os.path.join(out_dir, os.path.pardir, "samtools")
+    samtools_stats = samtools.run(bam_file, data, samtools_stats_dir)
+
+    stats_file = os.path.join(out_dir, "%s.txt" % dd.get_sample_name(data))
+    if not utils.file_exists(stats_file):
+        utils.safe_makedir(out_dir)
+        preseq = config_utils.get_program("preseq", data["config"])
+        params = _get_preseq_params(data, int(samtools_stats["Total_reads"]))
+        param_line = "-step {step} -extrap {extrap} -seg_len {seg_len}".format(**params)
+        with file_transaction(data, stats_file) as tx_out_file:
+            cmd = "{preseq} lc_extrap -bam -pe {bam_file} -o {tx_out_file} {param_line}".format(**locals())
+            do.run(cmd.format(**locals()), "preseq lc_extrap", data)
+
+    out = _prep_real_counts(bam_file, data, samtools_stats)
+
+    return {"base": stats_file,
+            "metrics": out}
+
+def _get_preseq_params(data, read_count):
+    """ Get parameters through resources.
+        If "step" or "extrap" limit are not provided, then calculate optimal values based on read count.
+    """
+    params = {
+        'seg_len': 100000,     # maximum segment length when merging paired end bam reads
+        'steps': 300,          # number of points on the plot
+        'extrap_fraction': 3,  # extrapolate up to X times read_count
+        'extrap': None,        # extrapolate up to X reads
+        'step': None,          # step size (number of reads between points on the plot)
+    }
+    params.update(config_utils.get_resources("preseq", data["config"]))
+
+    if params['step'] is None:
+        if params['extrap'] is not None:
+            unrounded__extrap = params['extrap']
+        else:
+            unrounded__extrap = read_count * params['extrap_fraction']
+        unrounded__step = unrounded__extrap // params['steps']
+        power_of_10 = 10 ** math.floor(math.log(unrounded__step, 10))
+        rounded__step = int(math.floor(unrounded__step // power_of_10) * power_of_10)
+        rounded__extrap = int(rounded__step) * params['steps']
+        params['step'] = rounded__step
+        params['extrap'] = rounded__extrap
+
+    elif params['extrap'] is None:
+        params['extrap'] = params['step'] * params['steps']
+
+    logger.info("Preseq: running {steps} steps of size {step}, extap limit {extrap}".format(**params))
+    return params
+
+def _prep_real_counts(bam_file, data, samtools_stats):
+    out = {}
+
+    if dd.get_coverage(data) and dd.get_coverage(data) not in ["None"]:
+        bed = dd.get_coverage_merged(data)
+        target_name = "coverage"
+    elif dd.get_coverage_interval(data) != "genome":
+        bed = dd.get_variant_regions_merged(data)
+        target_name = "variant_regions"
+    else:
+        bed = None
+        target_name = "genome"
+
+    dedupped = utils.get_in(data, ("config", "algorithm", "mark_duplicates"), True)
+
+    if bed:
+        out["Preseq_genome_size"] = pybedtools.BedTool(bed).total_coverage()
+        out["Preseq_read_count"] = sambamba.number_of_mapped_reads(
+            data, bam_file, keep_dups=True, bed_file=bed, target_name=target_name)
+        ontrg_unique_depth = cov.get_average_coverage(data, bam_file, bed, target_name)
+        if dedupped:
+            out["Preseq_unique_count"] = sambamba.number_of_mapped_reads(
+                data, bam_file, keep_dups=False, bed_file=bed, target_name=target_name)
+
+        # Counting average on-target alignment length, based on the equation:
+        #    avg depth ~~ num (unique) on-target alignments * avg on-target aln length / target size
+        total_alignments = out.get("Preseq_unique_count") or out["Preseq_read_count"]
+        out["Preseq_read_length"] = ontrg_unique_depth * out["Preseq_genome_size"] // total_alignments
+
+    else:  # WGS
+        out["Preseq_genome_size"] = sum([c.size for c in ref.file_contigs(dd.get_ref_file(data), data["config"])])
+        out["Preseq_read_count"] = int(samtools_stats["Total_reads"])
+        out["Preseq_read_length"] = int(samtools_stats["Average_read_length"])
+        if dedupped:
+            out["Preseq_unique_count"] = out["Preseq_read_count"] - int(samtools_stats["Duplicates"])
+
+    return out

--- a/bcbio/qc/samtools.py
+++ b/bcbio/qc/samtools.py
@@ -28,7 +28,9 @@ def _parse_samtools_stats(stats_file):
             "reads mapped": "Mapped_reads",
             "reads mapped and paired": "Mapped_paired_reads",
             "reads duplicated": "Duplicates",
-            "insert size average": "Average_insert_size"}
+            "insert size average": "Average_insert_size",
+            "average length": "Average_read_length",
+            }
     with open(stats_file) as in_handle:
         for line in in_handle:
             if not line.startswith("SN"):

--- a/docs/contents/configuration.rst
+++ b/docs/contents/configuration.rst
@@ -885,6 +885,23 @@ Quality control
   kraken will use it. You will find the results in the `qc` directory. You need
   to use `--datatarget kraken` during installation to make the minikraken
   database available.
+- ``preseq`` When set to `true`, runs the `lc_extrap` command of `Preseq <http://smithlabresearch.org/software/preseq>`_.
+  to predict the yield for future experiments. By default, it runs 300 steps of
+  estimation to get predictions for 3x of input, using the segment length of 100000.
+  You can override the parameters `seg_len`, `steps`, `extrap_fraction` using the :ref:`config-resources`: section::
+
+        resources:
+          preseq:
+            extrap_fraction: 5
+            steps: 500
+            seg_len: 5000
+
+And you can also set `extrap` and `step` parameters directly::
+
+        resources:
+          preseq:
+            extrap: 10000000
+            step: 30000
 
 .. _contaminants: https://ccb.jhu.edu/software/kraken/
 .. _custom database: https://github.com/DerrickWood/kraken


### PR DESCRIPTION
Runs [`preseq lc_extrap`](http://smithlabresearch.org/software/preseq/) that estimates the yield for future experiments by showing how many additional unique reads are sequenced for increasing total read count. 

Activated by adding `preseq: true` to the `algorithm` section. I wasn't sure if it should be done using `tools_on` or with its own parameter. However, I want to add another preseq command `c_curve` for yield estimation of lower input experiments, and it would make sense to support configuration like `preseq: lc_extrap` and `preseq: c_curve`.

Reasonable prediction parameters are calculated (estimation step and limit) based on the total read count, but also configurable in `resources` section (I described it in the docs).

To aid visibility through the MultiQC plot, bcbio adds some metadata into MultiQC config and writes a file with actual counts. It makes MultiQC convert the molecule numbers into depths of coverage, and display dots with actual coverages (see examples in this comment https://github.com/ewels/MultiQC/pull/461#issuecomment-301625384).

I'm not sure if I did everything right with cwl compatibility. Hope it works well, but I'll try to install bcbio-vm eventually to test it myself.