### PR TITLE
Preseq: add c_curve and support custom options

### DIFF
--- a/bcbio/pipeline/run_info.py
+++ b/bcbio/pipeline/run_info.py
@@ -463,10 +463,10 @@ ALGORITHM_KEYS = set(["platform", "aligner", "bam_clean", "bam_sort",
 ALG_ALLOW_BOOLEANS = set(["merge_bamprep", "mark_duplicates", "remove_lcr",
                           "clinical_reporting", "transcriptome_align",
                           "fusion_mode", "assemble_transcripts", "trim_reads",
-                          "recalibrate", "realign", "cwl_reporting", "save_diskspace", "preseq"])
+                          "recalibrate", "realign", "cwl_reporting", "save_diskspace"])
 ALG_ALLOW_FALSE = set(["aligner", "align_split_size", "bam_clean", "bam_sort",
                        "effects", "phasing", "mixup_check", "indelcaller",
-                       "variantcaller", "positional_umi", "maxcov_downsample"])
+                       "variantcaller", "positional_umi", "maxcov_downsample", "preseq"])
 
 ALG_DOC_URL = "https://bcbio-nextgen.readthedocs.org/en/latest/contents/configuration.html#algorithm-parameters"
 

--- a/bcbio/qc/preseq.py
+++ b/bcbio/qc/preseq.py
@@ -1,9 +1,8 @@
-"""Run Preseq, a tool that estimates the complexity of a library.
+"""Runs Preseq, a tool that estimates the complexity of a library.
 http://smithlabresearch.org/software/preseq/
 
-Uses the command `lc_extrap` that predicts the yield for future experiment
-by showing how many additional unique reads are sequenced for increasing
-total read count.
+Executes `lc_extrap` or `c_curve` commands that predict the yield
+for future experiments (for higher or lower input correspondingly).
 
 """
 import os
@@ -24,7 +23,8 @@ from bcbio.qc import samtools
 
 def run(bam_file, data, out_dir):
     out = {}
-    if not tz.get_in(["config", "algorithm", "preseq"], data):
+    preseq_cmd = tz.get_in(["config", "algorithm", "preseq"], data)
+    if not preseq_cmd:
         return out
 
     samtools_stats_dir = os.path.join(out_dir, os.path.pardir, "samtools")
@@ -34,44 +34,81 @@ def run(bam_file, data, out_dir):
     if not utils.file_exists(stats_file):
         utils.safe_makedir(out_dir)
         preseq = config_utils.get_program("preseq", data["config"])
-        params = _get_preseq_params(data, int(samtools_stats["Total_reads"]))
-        param_line = "-step {step} -extrap {extrap} -seg_len {seg_len}".format(**params)
+        params = _get_preseq_params(data, preseq_cmd, int(samtools_stats["Total_reads"]))
+        param_line = "{options} -step {step} -seg_len {seg_len} "
+        if preseq_cmd == "lc_extrap":
+            param_line += "-extrap {extrap} "
+        param_line = param_line.format(**params)
         with file_transaction(data, stats_file) as tx_out_file:
-            cmd = "{preseq} lc_extrap -bam -pe {bam_file} -o {tx_out_file} {param_line}".format(**locals())
-            do.run(cmd.format(**locals()), "preseq lc_extrap", data)
+            cmd = "{preseq} {preseq_cmd} -bam -pe {bam_file} -o {tx_out_file} {param_line}".format(**locals())
+            do.run(cmd.format(**locals()), "preseq " + preseq_cmd, data)
 
     out = _prep_real_counts(bam_file, data, samtools_stats)
 
     return {"base": stats_file,
             "metrics": out}
 
-def _get_preseq_params(data, read_count):
+def _get_preseq_params(data, preseq_cmd, read_count):
     """ Get parameters through resources.
         If "step" or "extrap" limit are not provided, then calculate optimal values based on read count.
     """
-    params = {
-        'seg_len': 100000,     # maximum segment length when merging paired end bam reads
-        'steps': 300,          # number of points on the plot
-        'extrap_fraction': 3,  # extrapolate up to X times read_count
-        'extrap': None,        # extrapolate up to X reads
-        'step': None,          # step size (number of reads between points on the plot)
+    defaults = {
+        'seg_len': 100000,        # maximum segment length when merging paired end bam reads
+        'steps': 300,             # number of points on the plot
+        'extrap_fraction': 3,     # extrapolate up to X times read_count
+        'extrap': None,           # extrapolate up to X reads
+        'step': None,             # step size (number of reads between points on the plot)
+        'options': '',
     }
-    params.update(config_utils.get_resources("preseq", data["config"]))
+    params = {}
 
-    if params['step'] is None:
-        if params['extrap'] is not None:
-            unrounded__extrap = params['extrap']
+    main_opts = [("-e", "-extrap"), ("-l", "-seg_len"), ("-s", "-step")]
+    other_opts = config_utils.get_resources("preseq", data["config"]).get("options", [])
+    if isinstance(other_opts, str):
+        other_opts = [other_opts]
+    for sht, lng in main_opts:
+        if sht in other_opts:
+            i = other_opts.index(sht)
+        elif lng in other_opts:
+            i = other_opts.index(lng)
         else:
-            unrounded__extrap = read_count * params['extrap_fraction']
-        unrounded__step = unrounded__extrap // params['steps']
-        power_of_10 = 10 ** math.floor(math.log(unrounded__step, 10))
-        rounded__step = int(math.floor(unrounded__step // power_of_10) * power_of_10)
-        rounded__extrap = int(rounded__step) * params['steps']
-        params['step'] = rounded__step
-        params['extrap'] = rounded__extrap
+            i = None
+        if i is not None:
+            params[lng[1:]] = other_opts[i + 1]
+            other_opts = other_opts[:i] + other_opts[i + 2:]
+    params['options'] = ' '.join(other_opts)
+    for k, v in config_utils.get_resources("preseq", data["config"]).items():
+        if k != 'options':
+            params[k] = v
 
-    elif params['extrap'] is None:
-        params['extrap'] = params['step'] * params['steps']
+    params['steps'] = params.get('steps', defaults['steps'])
+
+    if preseq_cmd == 'c_curve':
+        params['extrap_fraction'] = 1
+
+    else:
+        if params.get('step') is None:
+            if params.get('extrap') is None:
+                unrounded__extrap = read_count * params.get('extrap_fraction', defaults['extrap_fraction'])
+                unrounded__step = unrounded__extrap // params['steps']
+                if params.get('extrap_fraction') is not None:  # extrap_fraction explicitly provided
+                    params['extrap'] = unrounded__extrap
+                    params['step'] = unrounded__step
+                else:
+                    power_of_10 = 10 ** math.floor(math.log(unrounded__step, 10))
+                    rounded__step = int(math.floor(unrounded__step // power_of_10) * power_of_10)
+                    rounded__extrap = int(rounded__step) * params['steps']
+                    params['step'] = rounded__step
+                    params['extrap'] = rounded__extrap
+            else:
+                params['step'] = params['extrap'] // params['steps']
+
+        elif params.get('extrap') is None:
+            params['extrap'] = params['step'] * params['steps']
+
+    params['step'] = params.get('step', defaults['step'])
+    params['extrap'] = params.get('extrap', defaults['extrap'])
+    params['seg_len'] = params.get('seg_len', defaults['seg_len'])
 
     logger.info("Preseq: running {steps} steps of size {step}, extap limit {extrap}".format(**params))
     return params

--- a/docs/contents/configuration.rst
+++ b/docs/contents/configuration.rst
@@ -885,10 +885,11 @@ Quality control
   kraken will use it. You will find the results in the `qc` directory. You need
   to use `--datatarget kraken` during installation to make the minikraken
   database available.
-- ``preseq`` When set to `true`, runs the `lc_extrap` command of `Preseq <http://smithlabresearch.org/software/preseq>`_.
-  to predict the yield for future experiments. By default, it runs 300 steps of
-  estimation to get predictions for 3x of input, using the segment length of 100000.
-  You can override the parameters `seg_len`, `steps`, `extrap_fraction` using the :ref:`config-resources`: section::
+- ``preseq`` Accepts `lc_extrap` or `c_curve`, and runs Preseq <http://smithlabresearch.org/software/preseq>`_,
+  a tool that predicts the yield for future experiments. By default, it runs 300
+  steps of estimation using the segment length of 100000. The default extrapolation
+  limit for `lc_extrap` is 3x of the reads number. You can override the parameters
+  `seg_len`, `steps`, `extrap_fraction` using the :ref:`config-resources`: section::
 
         resources:
           preseq:
@@ -896,12 +897,14 @@ Quality control
             steps: 500
             seg_len: 5000
 
-And you can also set `extrap` and `step` parameters directly::
+And you can also set `extrap` and `step` parameters directly, as well as provide any
+other command line option via `options`::
 
         resources:
           preseq:
             extrap: 10000000
             step: 30000
+            options: ["-D"]
 
 .. _contaminants: https://ccb.jhu.edu/software/kraken/
 .. _custom database: https://github.com/DerrickWood/kraken


### PR DESCRIPTION
1. `preseq` option now accepts 2 values: `lc_extrap` and `c_curve`, each corresponding to a command of the same name. `c_curve` predicts complexity in lower input experiments. It supports the same resources parameters except `extrap` and `extrap_fraction`. 
Preseq usage in config now: `algorithm: preseq: c_curve` or `algorithm: preseq: lc_extrap`.
2. Supporting custom Preseq options in resources config, e.g. `resources: preseq: options: ["-D"]`. The override defaults and inferred best guesses.