### PR TITLE
Multiqc config

### DIFF
--- a/bcbio/qc/multiqc.py
+++ b/bcbio/qc/multiqc.py
@@ -53,7 +53,9 @@ def summary(*samples):
                     else:
                         export_tmp = ""
                     path_export = utils.local_path_export()
-                    cmd = "{path_export}{export_tmp} {multiqc} -f -l {input_list_file} -o {tx_out}"
+                    other_opts = config_utils.get_resources("multiqc", samples[0]["config"]).get("options", [])
+                    other_opts = " ".join(other_opts)
+                    cmd = "{path_export}{export_tmp} {multiqc} -f -l {input_list_file} {other_opts} -o {tx_out}"
                     do.run(cmd.format(**locals()), "Run multiqc")
                     if utils.file_exists(os.path.join(tx_out, "multiqc_report.html")):
                         shutil.move(os.path.join(tx_out, "multiqc_report.html"), out_file)

--- a/bcbio/qc/multiqc.py
+++ b/bcbio/qc/multiqc.py
@@ -68,6 +68,7 @@ def summary(*samples):
                 data_files += glob.glob(os.path.join(out_dir, "report", "*", "*.tsv"))
                 data_files += glob.glob(os.path.join(out_dir, "report", "*", "*.yaml"))
                 data_files += glob.glob(os.path.join(out_dir, "report", "*.R*"))
+                data_files += glob.glob(os.path.join(out_dir, "multiqc_config.yaml"))
                 data_files.append(file_list)
                 if "summary" not in data:
                     data["summary"] = {}


### PR DESCRIPTION
MultiQC:
1. upload multiqc_config.yaml into final to allow reruns.
2. support custom options in MultiQC resources (#2045), e.g.:
```
resources:
  multiqc:
    options: ["--cl_config", "'qualimap_config: { general_stats_coverage: [20,40,200] }'"]
```
Perhaps it makes sense to document it in `configuration.rst`, but not sure of the best way.