### PR TITLE
Kraken: do not require BAMs or aligners to run

### DIFF
--- a/bcbio/pipeline/main.py
+++ b/bcbio/pipeline/main.py
@@ -145,7 +145,7 @@ def variant2pipeline(config, run_info_yaml, parallel, dirs, samples):
     with prun.start(_wres(parallel, ["gatk", "gatk-vqsr", "snpeff", "bcbio_variation",
                                      "gemini", "samtools", "fastqc", "sambamba",
                                      "bcbio-variation-recall", "qsignature",
-                                     "svcaller", "preseq"]),
+                                     "svcaller", "kraken", "preseq"]),
                     samples, config, dirs, "multicore2",
                     multiplier=structural.parallel_multiplier(samples)) as run_parallel:
         with profile.report("joint squaring off/backfilling", dirs):

--- a/bcbio/pipeline/sample.py
+++ b/bcbio/pipeline/sample.py
@@ -156,6 +156,8 @@ def process_alignment(data, alt_input=None):
         data["work_bam"] = None
     elif not fastq1:
         raise ValueError("No 'files' specified for input sample: %s" % dd.get_sample_name(data))
+    elif "kraken" in config["algorithm"]:  # kraken doesn's need bam
+        pass
     else:
         raise ValueError("Could not process input file from sample configuration. \n" +
                          fastq1 +

--- a/bcbio/qc/kraken.py
+++ b/bcbio/qc/kraken.py
@@ -4,6 +4,7 @@ https://ccb.jhu.edu/software/kraken/
 """
 import os
 import shutil
+import toolz as tz
 
 from bcbio import bam, install, utils
 from bcbio.distributed.transaction import file_transaction, tx_tmpdir
@@ -12,15 +13,15 @@ from bcbio.provenance import do
 from bcbio.pipeline import datadict as dd
 from bcbio.pipeline import config_utils
 
-def run(bam_file, data, out_dir):
+def run(_, data, out_dir):
     """Run kraken, generating report in specified directory and parsing metrics.
        Using only first paired reads.
     """
     # logger.info("Number of aligned reads < than 0.60 in %s: %s" % (dd.get_sample_name(data), ratio))
     logger.info("Running kraken to determine contaminant: %s" % dd.get_sample_name(data))
-    ratio = bam.get_aligned_reads(bam_file, data)
+    # ratio = bam.get_aligned_reads(bam_file, data)
     out = out_stats = None
-    db = data['config']["algorithm"]["kraken"]
+    db = tz.get_in(["config", "algorithm", "kraken"], data)
     kraken_cmd = config_utils.get_program("kraken", data["config"])
     if db == "minikraken":
         db = os.path.join(install._get_data_dir(), "genomes", "kraken", "minikraken")


### PR DESCRIPTION
Not the most elegant solution, but since we already have a [special check](https://github.com/chapmanb/bcbio-nextgen/blob/072f90f9a803bfde1449ab80c3665fae4515c617/bcbio/ngsalign/alignprep.py#L228) for kraken to keep the ogirinal input files, I hope it doesn't look too bad to treat kraken specially in QC as well.
cc @lpantano 