### PR TITLE
VEP: replaced ExAC with GnomAD

### DIFF
--- a/bcbio/variation/effects.py
+++ b/bcbio/variation/effects.py
@@ -165,7 +165,7 @@ def run_vep(in_file, data):
                         "--offline", "--dir", vep_dir,
                        "--symbol", "--numbers", "--biotype", "--total_length", "--canonical",
                        "--gene_phenotype", "--ccds", "--uniprot", "--domains", "--regulatory",
-                       "--protein", "--tsl", "--appris", "--af", "--max_af", "--af_1kg", "--af_esp", "--af_exac",
+                       "--protein", "--tsl", "--appris", "--af", "--max_af", "--af_1kg", "--af_esp", "--af_gnomad",
                        "--pubmed", "--variant_class"] + config_args
                 perl_exports = utils.get_perl_exports()
                 # Remove empty fields (';;') which can cause parsing errors downstream


### PR DESCRIPTION
The `--af_exac` flag had been deprecated in favor of the `--af_gnomad` flags, which includes annotations of all GnomAD exome frequencies. Using the `--af_exac` flag breaks VEP, even though it's still referenced in the docs.
see ensembl/ensembl-vep#76