### PR TITLE
Clean up MultiQC for germline variants calling

### DIFF
--- a/bcbio/pipeline/qcsummary.py
+++ b/bcbio/pipeline/qcsummary.py
@@ -139,6 +139,8 @@ def _run_qc_tools(bam_file, data):
     for program_name in dd.get_algorithm_qc(data):
         if not bam_file and program_name != "kraken":  # kraken doesn't need bam
             continue
+        if dd.get_phenotype(data) == "germline" and program_name != "variants":
+            continue
         qc_fn = tools[program_name]
         cur_qc_dir = os.path.join(qc_dir, program_name)
         out = qc_fn(bam_file, data, cur_qc_dir)

--- a/bcbio/pipeline/variation.py
+++ b/bcbio/pipeline/variation.py
@@ -78,9 +78,11 @@ def postprocess_variants(items):
                                               tz.get_in(("genome_resources", "variation"), data, {}),
                                               data, orig_items)
         logger.info("Prioritization for %s" % cur_name)
-        data[vrn_key] = prioritize.handle_vcf_calls(data[vrn_key], data, orig_items)
-        logger.info("Germline extraction for %s" % cur_name)
-        data = germline.extract(data, orig_items)
+        prio_vrn_file = prioritize.handle_vcf_calls(data[vrn_key], data, orig_items)
+        if prio_vrn_file != data[vrn_key]:
+            data[vrn_key] = prio_vrn_file
+            logger.info("Germline extraction for %s" % cur_name)
+            data = germline.extract(data, orig_items)
 
         if dd.get_align_bam(data):
             data = damage.run_filter(data[vrn_key], dd.get_align_bam(data), dd.get_ref_file(data),

--- a/bcbio/qc/multiqc.py
+++ b/bcbio/qc/multiqc.py
@@ -25,6 +25,7 @@ from bcbio.pipeline import config_utils
 from bcbio.bam import ref
 from bcbio.structural import annotate
 from bcbio.variation import bedutils
+from bcbio.qc.variant import get_active_vcinfo
 from bcbio.upload import get_all_upload_paths_from_sample
 
 def summary(*samples):
@@ -191,6 +192,45 @@ def _create_config_file(out_dir, samples):
     if any(("qualimap" in dd.get_tools_on(d) or "qualimap_full" in dd.get_tools_on(d)) for d in samples):
         out["table_columns_visible"]["bcbio"] = {"Average_insert_size": False}
         out["table_columns_visible"]["FastQC"] = {"percent_gc": False}
+
+    # Setting the module order
+    module_order = []
+    module_order.extend([
+        "bcbio",
+        "samtools",
+        "goleft_indexcov"
+    ])
+    out['bcftools'] = {'write_separate_table': True}
+    # if germline calling was performed:
+    if any("germline" in (get_active_vcinfo(s) or {})  # tumor-only somatic with germline extraction
+           or dd.get_phenotype(s) == "germline"        # or paired somatic with germline calling for normal
+           for s in samples):
+        # Split somatic and germline variant stats into separate multiqc submodules,
+        # with somatic going into General Stats, and germline going into a separate table:
+        module_order.extend([{
+            'bcftools': {
+                'name': 'Bcftools (somatic)',
+                'info': 'Bcftools stats for somatic variant calls only.',
+                'path_filters': ['*_bcftools_stats.txt'],
+                'write_general_stats': True,
+            }},
+            {'bcftools': {
+                'name': 'Bcftools (germline)',
+                'info': 'Bcftools stats for germline variant calls only.',
+                'path_filters': ['*_bcftools_stats_germline.txt'],
+                'write_general_stats': False
+            }},
+        ])
+    else:
+        module_order.append("bcftools")
+    module_order.extend([
+        "picard",
+        "qualimap",
+        "snpeff",
+        "fastqc",
+        "preseq",
+    ])
+    out["module_order"] = module_order
 
     preseq_samples = [s for s in samples if tz.get_in(["config", "algorithm", "preseq"], s)]
     if preseq_samples:

--- a/bcbio/qc/multiqc.py
+++ b/bcbio/qc/multiqc.py
@@ -188,9 +188,9 @@ def _create_config_file(out_dir, samples):
     out = {"table_columns_visible": dict()}
 
     # Avoid duplicated bcbio columns with qualimap
-    if any(("qualimap" in dd.get_tools_on(d) or "qualimap_full" in dd.get_tools_on(d))
-           for d in samples):
+    if any(("qualimap" in dd.get_tools_on(d) or "qualimap_full" in dd.get_tools_on(d)) for d in samples):
         out["table_columns_visible"]["bcbio"] = {"Average_insert_size": False}
+        out["table_columns_visible"]["FastQC"] = {"percent_gc": False}
 
     preseq_samples = [s for s in samples if tz.get_in(["config", "algorithm", "preseq"], s)]
     if preseq_samples:

--- a/bcbio/qc/variant.py
+++ b/bcbio/qc/variant.py
@@ -14,14 +14,22 @@ from bcbio.pipeline import datadict as dd
 from bcbio.pipeline import config_utils
 from bcbio.provenance import do
 
-def run(bam_file, data, out_dir):
+def run(_, data, out_dir):
     """Prepare variants QC analysis: bcftools stats and snpEff output.
     """
     out = []
-    for stat_fn in [_bcftools_stats, _snpeff_stats]:
-        out_file = stat_fn(data, out_dir)
-        if out_file:
-            out.append(out_file)
+    vcinfo = get_active_vcinfo(data)
+    if vcinfo:
+        if dd.get_phenotype(data) != "germline":
+            out.append(_bcftools_stats(data, out_dir))
+            if "germline" in vcinfo:
+                out.append(_bcftools_stats(data, out_dir, "germline", germline=True))
+        else:
+            out.append(_bcftools_stats(data, out_dir, germline=True))
+
+    out.append(_snpeff_stats(data, out_dir))
+
+    out = [item for item in out if item]
     if out:
         return {"base": out[0], "secondary": out[1:]}
 
@@ -35,6 +43,35 @@ def _snpeff_stats(data, out_dir):
             with file_transaction(data, out_file) as tx_out_file:
                 shutil.copy(effects_csv, tx_out_file)
             return out_file
+
+def _bcftools_stats(data, out_dir, vcf_file_key=None, germline=False):
+    """Run bcftools stats.
+    """
+    vcinfo = get_active_vcinfo(data)
+    if vcinfo:
+        out_dir = utils.safe_makedir(out_dir)
+        vcf_file = vcinfo[vcf_file_key or "vrn_file"]
+        if tz.get_in(("config", "algorithm", "jointcaller"), data):
+            opts = ""
+        else:
+            opts = "-f PASS"
+        name = dd.get_sample_name(data)
+        out_file = os.path.join(out_dir, "%s_bcftools_stats%s.txt" % (name, ("_germline" if germline else "")))
+        bcftools = config_utils.get_program("bcftools", data["config"])
+        if not utils.file_exists(out_file):
+            with file_transaction(data, out_file) as tx_out_file:
+                orig_out_file = os.path.join(os.path.dirname(tx_out_file), "orig_%s" % os.path.basename(tx_out_file))
+                cmd = ("{bcftools} stats -s {name} {opts} {vcf_file} > {orig_out_file}")
+                do.run(cmd.format(**locals()), "bcftools stats %s" % name)
+                with open(orig_out_file) as in_handle:
+                    with open(tx_out_file, "w") as out_handle:
+                        for line in in_handle:
+                            if line.startswith("ID\t"):
+                                parts = line.split("\t")
+                                parts[-1] = "%s\n" % name
+                                line = "\t".join(parts)
+                            out_handle.write(line)
+        return out_file
 
 def get_active_vcinfo(data):
     """Use first caller if ensemble is not active
@@ -53,32 +90,3 @@ def get_active_vcinfo(data):
                 active_vs.append(v)
         if len(active_vs) > 0:
             return active_vs[0]
-
-def _bcftools_stats(data, out_dir):
-    """Run bcftools stats.
-    """
-    vcinfo = get_active_vcinfo(data)
-    if vcinfo:
-        out_dir = utils.safe_makedir(out_dir)
-        vcf_file = vcinfo["vrn_file"]
-        if tz.get_in(("config", "algorithm", "jointcaller"), data):
-            opts = ""
-        else:
-            opts = "-f PASS"
-        name = dd.get_sample_name(data)
-        out_file = os.path.join(out_dir, "%s_bcftools_stats.txt" % name)
-        bcftools = config_utils.get_program("bcftools", data["config"])
-        if not utils.file_exists(out_file):
-            with file_transaction(data, out_file) as tx_out_file:
-                orig_out_file = os.path.join(os.path.dirname(tx_out_file), "orig_%s" % os.path.basename(tx_out_file))
-                cmd = ("{bcftools} stats -s {name} {opts} {vcf_file} > {orig_out_file}")
-                do.run(cmd.format(**locals()), "bcftools stats %s" % dd.get_sample_name(data))
-                with open(orig_out_file) as in_handle:
-                    with open(tx_out_file, "w") as out_handle:
-                        for line in in_handle:
-                            if line.startswith("ID\t"):
-                                parts = line.split("\t")
-                                parts[-1] = "%s\n" % name
-                                line = "\t".join(parts)
-                            out_handle.write(line)
-        return out_file

--- a/bcbio/structural/manta.py
+++ b/bcbio/structural/manta.py
@@ -61,8 +61,6 @@ def _select_sample(data, variant_file, work_dir):
     """Select current sample from original call file.
     """
     sample_name = dd.get_sample_name(data)
-    if dd.get_phenotype(data) == "germline":
-        variant_file = germline.fix_germline_samplename(variant_file, sample_name, data)
 
     out_file = os.path.join(work_dir, "%s-%s.vcf.gz" % (utils.splitext_plus(os.path.basename(variant_file))[0],
                                                         sample_name))

--- a/bcbio/upload/__init__.py
+++ b/bcbio/upload/__init__.py
@@ -397,7 +397,7 @@ def _maybe_add_summary(algorithm, sample, out):
     return out
 
 def _maybe_add_alignment(algorithm, sample, out):
-    if _has_alignment_file(algorithm, sample):
+    if _has_alignment_file(algorithm, sample) and dd.get_phenotype(sample) != "germline":
         for (fname, ext, isplus) in [(sample.get("work_bam"), "ready", False),
                                      (dd.get_disc_bam(sample), "disc", True),
                                      (dd.get_sr_bam(sample), "sr", True)]:

--- a/bcbio/variation/germline.py
+++ b/bcbio/variation/germline.py
@@ -28,7 +28,6 @@ def split_somatic(items):
             cur = utils.deepish_copy(paired.normal_data)
             vc = dd.get_variantcaller(cur)
             if isinstance(vc, dict) and "germline" in vc:
-                cur["description"] = "%s-germline" % cur["description"]
                 if cur["description"] not in germline_added:
                     germline_added.add(cur["description"])
                     cur["rgnames"]["sample"] = cur["description"]
@@ -59,20 +58,12 @@ def remove_align_qc_tools(data):
 
 def extract(data, items):
     """Extract germline calls for the given sample, if tumor only.
-
-    For germline calling done separately, fix VCF sample naming to match.
     """
     if vcfutils.get_paired_phenotype(data):
         if len(items) == 1:
             germline_vcf = _remove_prioritization(data["vrn_file"], data)
             germline_vcf = vcfutils.bgzip_and_index(germline_vcf, data["config"])
             data["vrn_file_plus"] = {"germline": germline_vcf}
-    elif dd.get_phenotype(data) == "germline":
-        sample_name = dd.get_sample_name(data)
-        vcf_samples = vcfutils.get_samples(data["vrn_file"])
-        if (sample_name.endswith("-germline") and len(vcf_samples) == 1
-              and sample_name.replace("-germline", "") == vcf_samples[0]):
-            data["vrn_file"] = fix_germline_samplename(data["vrn_file"], sample_name, data)
     return data
 
 def fix_germline_samplename(in_file, sample_name, data):


### PR DESCRIPTION
- When germline calling requested for "normal" samples, write germline VCF into the "normal" results folder rather than creating a separate `<normal-sample>-germline` folder with duplicated BAM and stats.
- Run Bcftools twice, once for somatic and once for germline calls; both for the paired case (when germline calling was performed on normals), and for the single tumors (when somatic prioritization was done with the following extraction of germline variants). 
- Report both of the Bcftools runs in MultiQC (needs MultiQC PR https://github.com/ewels/MultiQC/pull/608 to be accepted).
- Remove the germline call stats from the General Stats MultiQC table, and rather report them in a separate table right above the germline Bcftools section (also needs the MultiQC PR):
![screen shot 2017-10-11 at 16 50 32](https://user-images.githubusercontent.com/1575412/31424059-dedcc408-aea3-11e7-8606-507dc23611d0.png)


Addresses the clean up part at https://github.com/chapmanb/bcbio-nextgen/issues/2081