### PR TITLE
added idxstats to samtools qc step

### DIFF
--- a/bcbio/qc/samtools.py
+++ b/bcbio/qc/samtools.py
@@ -12,14 +12,21 @@ def run(bam_file, data, out_dir):
     """Run samtools stats with reports on mapped reads, duplicates and insert sizes.
     """
     stats_file = os.path.join(out_dir, "%s.txt" % dd.get_sample_name(data))
+    idxstats_file = os.path.join(out_dir, "%s-idxstats.txt" % dd.get_sample_name(data))
+    samtools = config_utils.get_program("samtools", data["config"])
     if not utils.file_exists(stats_file):
         utils.safe_makedir(out_dir)
-        samtools = config_utils.get_program("samtools", data["config"])
         with file_transaction(data, stats_file) as tx_out_file:
             cores = dd.get_num_cores(data)
             cmd = "{samtools} stats -@ {cores} {bam_file}"
             cmd += " > {tx_out_file}"
             do.run(cmd.format(**locals()), "samtools stats", data)
+    if not utils.file_exists(idxstats_file):
+        utils.safe_makedir(out_dir)
+        with file_transaction(data, idxstats_file) as tx_out_file:
+            cmd = "{samtools} idxstats {bam_file}"
+            cmd += " > {tx_out_file}"
+            do.run(cmd.format(**locals()), "samtools index stats", data)
     out = _parse_samtools_stats(stats_file)
     return out
 


### PR DESCRIPTION
Hi Brad,

I took the liberty of adding a little QC step to the samtools routine. Using Idxstats in multiqc enables us to quickly check for the gender of samples based of the XY read count.

This is just a basic implementation, and I'm not sure of more steps should be added. I was hoping you could provide further plumbing if necessary.

Thanks a lot!
M