### PR TITLE
Fix uploading germline VCFs for normals

### DIFF
--- a/bcbio/structural/__init__.py
+++ b/bcbio/structural/__init__.py
@@ -101,7 +101,7 @@ def finalize_sv(samples, config):
         batch = dd.get_batch(final) or dd.get_sample_name(final)
         batches = batch if isinstance(batch, (list, tuple)) else [batch]
         if len(batches) > 1:
-            lead_batches[dd.get_sample_name(final)] = batches[0]
+            lead_batches[(dd.get_sample_name(final), dd.get_phenotype(final))] = batches[0]
         for batch in batches:
             try:
                 by_batch[batch].append(final)
@@ -112,7 +112,7 @@ def finalize_sv(samples, config):
         if any("svplots" in dd.get_tools_on(d) for d in items):
             items = plot.by_regions(items)
         for data in items:
-            if lead_batches.get(dd.get_sample_name(data)) in [batch, None]:
+            if lead_batches.get((dd.get_sample_name(final), dd.get_phenotype(final))) in [batch, None]:
                 out.append([data])
     return out
 


### PR DESCRIPTION
Thanks @ohofmann for spotting the issue.

Changing `<normal>-germline` to `<normal>` lead to an issue during one of the SV callings steps where the samples are grouped by name. This part of the code wasn't run in by my test cases so it wasn't cought earlier unfortunately.

Fixing that now.