### PR TITLE
Fixed missing import of bio.structrural.shared

### DIFF
--- a/bcbio/structural/cnvkit.py
+++ b/bcbio/structural/cnvkit.py
@@ -23,7 +23,7 @@ from bcbio.pipeline import datadict as dd
 from bcbio.pipeline import config_utils
 from bcbio.provenance import do
 from bcbio.variation import effects, ploidy, population, vcfutils
-from bcbio.structural import annotate, plot
+from bcbio.structural import annotate, plot, shared
 
 def use_general_sv_bins(data):
     """Check if we should use a general binning approach for a sample.


### PR DESCRIPTION
Line 131 in cnvkit.py calls shared.find_case_control() but `shared` module was
not imported.