### PR TITLE
Fix autopair UMI tagging

### DIFF
--- a/scripts/bcbio_fastq_umi_prep.py
+++ b/scripts/bcbio_fastq_umi_prep.py
@@ -128,7 +128,7 @@ def _find_umi(files):
         return exts["R1"], exts["R2"], exts["I1"]
     else:
         assert "R3" in exts, exts
-        return exts["R1"], exts["R3"], exts["R2"]
+        return exts["R1"], exts["R2"], exts["R3"]
 
 def _commonprefix(files):
     """Retrieve a common prefix for files without extra _R1 _I1 extensions.


### PR DESCRIPTION
`_find_umi` returned the files in the wrong order (R1, R3, R2) so R1 and
the UMI file would get tagged with reads in R2 instead.