### PR TITLE
support for BCBIOPATH: proof of concept

### DIFF
--- a/bcbio/setpath.py
+++ b/bcbio/setpath.py
@@ -1,0 +1,60 @@
+"""Update the PATH environment variable to reflect the value of BCBIOPATH.
+
+"""
+
+import os
+
+def _maybe_prepend(original, to_prepend):
+    """Prepend unique non-empty paths unless already present.
+
+    original and to_prepend are expected to be strings corresponding to
+    os.pathsep-separated lists of filepaths.
+
+    If to_prepend is the empty sting, original is returned.
+
+    examples:
+    # Unix
+    _maybe_prepend('/foo:/bar:/foo', '/foo:/baz:/baz') -> '/baz:/foo:/bar:/foo'
+    _maybe_prepend('/baz', '/foo::/bar:/foo')          -> '/foo:/bar:/baz'
+    _maybe_prepend('/foo:/bar:/foo', '')               -> '/foo:/bar:/foo'
+
+    """
+
+    sep = os.pathsep
+
+    def split_path_value(path_value):
+        return [] if path_value == '' else path_value.split(sep)
+
+    new_paths = split_path_value(to_prepend)
+
+    if new_paths == []:
+        return original
+
+    paths = split_path_value(original)
+
+    paths_lookup = set(paths)
+
+    # collect in prefix all unique non-empty paths in new_paths that are not
+    # already in paths
+    prefix = []
+    for path in new_paths:
+        if path not in paths_lookup and path != '':
+            prefix.append(path)
+            paths_lookup.add(path)
+
+    return sep.join(prefix + paths)
+
+
+if __name__ == '__main__':
+
+    # check examples (poor-man's doctest)
+    print _maybe_prepend('/foo:/bar:/foo', '/foo:/baz:/baz')
+    print _maybe_prepend('/baz', '/foo::/bar:/foo')
+    print _maybe_prepend('/foo:/bar:/foo', '')
+
+else:
+
+    # possibly update PATH
+    os.environ['PATH'] = _maybe_prepend(os.environ.get('PATH', ''),
+                                        os.environ.get('BCBIOPATH', ''))
+    del _maybe_prepend

--- a/bcbio/setpath.py
+++ b/bcbio/setpath.py
@@ -4,57 +4,59 @@
 
 import os
 
-def _maybe_prepend(original, to_prepend):
-    """Prepend unique non-empty paths unless already present.
+def _prepend(original, to_prepend):
+    """Prepend paths in a string representing a list of paths to another.
 
-    original and to_prepend are expected to be strings corresponding to
+    original and to_prepend are expected to be strings representing
     os.pathsep-separated lists of filepaths.
 
-    If to_prepend is the empty sting, original is returned.
+    If to_prepend is None, original is returned.
+
+    The list of paths represented in the returned value consists of the first of
+    occurrences of each non-empty path in the list obtained by prepending the
+    paths in to_prepend to the paths in original.
 
     examples:
     # Unix
-    _maybe_prepend('/foo:/bar:/foo', '/foo:/baz:/baz') -> '/baz:/foo:/bar:/foo'
-    _maybe_prepend('/baz', '/foo::/bar:/foo')          -> '/foo:/bar:/baz'
-    _maybe_prepend('/foo:/bar:/foo', '')               -> '/foo:/bar:/foo'
+    _prepend('/b:/d:/a:/d', '/a:/b:/c:/a') -> '/a:/b:/c:/d'
+    _prepend('/a:/b:/a', '/a:/c:/c')       -> '/a:/c:/b'
+    _prepend('/c', '/a::/b:/a')            -> '/a:/b:/c'
+    _prepend('/a:/b:/a', None)             -> '/a:/b:/a'
+    _prepend('/a:/b:/a', '')               -> '/a:/b'
 
     """
+
+    if to_prepend is None:
+        return original
 
     sep = os.pathsep
 
     def split_path_value(path_value):
         return [] if path_value == '' else path_value.split(sep)
 
-    new_paths = split_path_value(to_prepend)
+    seen = set()
 
-    if new_paths == []:
-        return original
+    components = []
+    for path in split_path_value(to_prepend) + split_path_value(original):
+        if path not in seen and path != '':
+            components.append(path)
+            seen.add(path)
 
-    paths = split_path_value(original)
-
-    paths_lookup = set(paths)
-
-    # collect in prefix all unique non-empty paths in new_paths that are not
-    # already in paths
-    prefix = []
-    for path in new_paths:
-        if path not in paths_lookup and path != '':
-            prefix.append(path)
-            paths_lookup.add(path)
-
-    return sep.join(prefix + paths)
+    return sep.join(components)
 
 
 if __name__ == '__main__':
 
     # check examples (poor-man's doctest)
-    print _maybe_prepend('/foo:/bar:/foo', '/foo:/baz:/baz')
-    print _maybe_prepend('/baz', '/foo::/bar:/foo')
-    print _maybe_prepend('/foo:/bar:/foo', '')
+    print _prepend('/b:/d:/a:/d', '/a:/b:/c:/a')
+    print _prepend('/a:/b:/a', '/a:/c:/c')
+    print _prepend('/c', '/a::/b:/a')
+    print _prepend('/a:/b:/a', None)
+    print _prepend('/a:/b:/a', '')
 
 else:
 
     # possibly update PATH
-    os.environ['PATH'] = _maybe_prepend(os.environ.get('PATH', ''),
-                                        os.environ.get('BCBIOPATH', ''))
-    del _maybe_prepend
+    os.environ['PATH'] = _prepend(os.environ.get('PATH', ''),
+                                  os.environ.get('BCBIOPATH', None))
+    del _prepend

--- a/scripts/bcbio_nextgen.py
+++ b/scripts/bcbio_nextgen.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python -Es
+#!/n/app/bcbio/dev/anaconda/bin/python -s
+
 """Run an automated analysis pipeline for high throughput sequencing data.
 
 Handles runs in local or distributed mode based on the command line or

--- a/scripts/bcbio_nextgen.py
+++ b/scripts/bcbio_nextgen.py
@@ -30,7 +30,7 @@ import os
 import argparse
 import sys
 
-from bcbio import install, utils, workflow
+from bcbio import setpath, install, utils, workflow
 from bcbio.illumina import machine
 from bcbio.distributed import runfn, clargs
 from bcbio.pipeline.main import run_main


### PR DESCRIPTION
The proposed change provides support for an optional `BCBIOPATH` environment variable.

If this variable is set and non-empty, the non-empty paths it mentions are prepended to `PATH`.  (If `BCBIOPATH` is unset, this code is essentially a no-op.)

The updating of `PATH` takes place the first time that `bcbio.setpath` is `import`'ed.  (Afterwards, `bcbio.setpath` remains as an inert placeholder.)

As the message for the PR's commit indicates, this is only a proof of concept.  I don't expect it to be incorporated into master as-is, but I hope it could be incorporated with little aditional work.

The name `BCBIOPATH` is only a suggestion.  Please feel free to change it if desired.

I have done some light, preliminary testing of the modified code, and it seems to work well, but more thorough testing is in order.
