### PR TITLE
bcbio/setpath.py: initial commit

### DIFF
--- a/bcbio/setpath.py
+++ b/bcbio/setpath.py
@@ -1,0 +1,65 @@
+"""Update the PATH environment variable to reflect the value of BCBIOPATH.
+
+"""
+
+import os
+
+def _prepend(original, to_prepend):
+    """Prepend paths in a string representing a list of paths to another.
+
+    original and to_prepend are expected to be strings representing
+    os.pathsep-separated lists of filepaths.
+
+    If to_prepend is None, original is returned.
+
+    The list of paths represented in the returned value consists of the first of
+    occurrences of each non-empty path in the list obtained by prepending the
+    paths in to_prepend to the paths in original.
+
+    examples:
+    # Unix
+    _prepend('/b:/d:/a:/d', '/a:/b:/c:/a') -> '/a:/b:/c:/d'
+    _prepend('/a:/b:/a', '/a:/c:/c')       -> '/a:/c:/b'
+    _prepend('/c', '/a::/b:/a')            -> '/a:/b:/c'
+    _prepend('/a:/b:/a', None)             -> '/a:/b:/a'
+    _prepend('/a:/b:/a', '')               -> '/a:/b'
+
+    """
+
+    if to_prepend is None:
+        return original
+
+    sep = os.pathsep
+
+    def split_path_value(path_value):
+        return [] if path_value == '' else path_value.split(sep)
+
+    seen = set()
+
+    components = []
+    for path in split_path_value(to_prepend) + split_path_value(original):
+        if path not in seen and path != '':
+            components.append(path)
+            seen.add(path)
+
+    return sep.join(components)
+
+
+def prepend_bcbiopath():
+    """Prepend paths in the BCBIOPATH environment variable (if any) to PATH.
+
+    If BCBIOPATH is not set, this function is a no-op.
+    """
+
+    os.environ['PATH'] = _prepend(os.environ.get('PATH', ''),
+                                  os.environ.get('BCBIOPATH', None))
+
+
+if __name__ == '__main__':
+
+    # check examples (poor-man's doctest)
+    print _prepend('/b:/d:/a:/d', '/a:/b:/c:/a')
+    print _prepend('/a:/b:/a', '/a:/c:/c')
+    print _prepend('/c', '/a::/b:/a')
+    print _prepend('/a:/b:/a', None)
+    print _prepend('/a:/b:/a', '')


### PR DESCRIPTION
The code in this PR addresses the first point in https://github.com/chapmanb/bcbio-nextgen/pull/2124#issuecomment-339320006 .

In this version of the `bcbio/setpath.py`, the modification to `PATH` can happen only through a function call, rather than through a side-effect of `import`.  (I will include modifications involving the actual invocations of this function in a separate PR.)