### PR TITLE
Update pandas sort syntax for integration/rnaseq/test_ericscript.py

### DIFF
--- a/tests/integration/rnaseq/test_ericscript.py
+++ b/tests/integration/rnaseq/test_ericscript.py
@@ -135,6 +135,6 @@ def _load_result_file(fname):
         'fusiontype'
     ]
     sort_by = ['EnsemblGene1', 'EnsemblGene2']
-    df = pd.read_csv(fname, sep='\t')[columns_to_keep].sort(sort_by)
+    df = pd.read_csv(fname, sep='\t')[columns_to_keep].sort_values(by=sort_by)
     df.index = range(len(df))
     return df


### PR DESCRIPTION
Although a tiny fix, it helps to get all test in ` integration/rnaseq/test_ericscript.py` finish successfully :) 
The next thing is to get `CheckDB.R`  of the original `ericrscipt`  to work correctly with bcbio_nextgen bwa version. The file is in here: samtools0/share/ericscript-0.5.5-1/lib/R/CheckDB.R