### PR TITLE
MultiQC secondary files: add multiqc_data.json, remove globs

### DIFF
--- a/bcbio/qc/multiqc.py
+++ b/bcbio/qc/multiqc.py
@@ -70,9 +70,10 @@ def summary(*samples):
             data_files.add(os.path.join(out_dir, "report", "metrics", dd.get_sample_name(data) + "_bcbio.txt"))
         data_files.add(os.path.join(out_dir, "report", "metrics", "target_info.yaml"))
         data_files.add(os.path.join(out_dir, "multiqc_config.yaml"))
+        data_files = [f for f in data_files if f and utils.file_exists(f)]
         if "summary" not in samples[0]:
             samples[0]["summary"] = {}
-        samples[0]["summary"]["multiqc"] = {"base": out_file, "secondary": list(data_files)}
+        samples[0]["summary"]["multiqc"] = {"base": out_file, "secondary": data_files}
 
         data_json = os.path.join(out_dir, "multiqc_data", "multiqc_data.json")
         data_json_final = _save_uploaded_data_json(samples, data_json, os.path.join(out_dir, "multiqc_data"))

--- a/bcbio/utils.py
+++ b/bcbio/utils.py
@@ -14,9 +14,9 @@ import fnmatch
 import subprocess
 import sys
 import types
-
 import toolz as tz
 import yaml
+from collections import Mapping, OrderedDict
 
 
 try:
@@ -871,3 +871,13 @@ class LazyImport(types.ModuleType):
     def __repr__(self):
         return "<module '%s' will be lazily loaded>" %\
                 object.__getattribute__(self,'__name__')
+
+def walk_json(d, func):
+    """ Walk over a parsed JSON nested structure `d`, apply `func` to each leaf element and replace it with result
+    """
+    if isinstance(d, Mapping):
+        return OrderedDict((k, walk_json(v, func)) for k, v in d.items())
+    elif isinstance(d, list):
+        return [walk_json(v, func) for v in d]
+    else:
+        return func(d)


### PR DESCRIPTION
Following the discussion in Slack, adding `multiqc_data.json` and cleaning up the secondary file list to get rid of globs, so it makes it more suitable for CWL definitions. Not adding changes to `cwl/defs.py` yet as I still don't have a test set up for that and don't want to break anything.

Also fixing work-rooted paths in `multiqc_data.json`, similarly to those in `list_files.txt`, to make MegaQC function out of just `final` directory.