### PR TITLE
Add Break Point Inspector for Manta calls filtering

### DIFF
--- a/bcbio/cwl/defs.py
+++ b/bcbio/cwl/defs.py
@@ -375,7 +375,7 @@ def _variant_sv(checkpoints):
                             cwlout(["sv", "vrn_file"], ["File", "null"], [".tbi"]),
                             cwlout("inherit")])],
             "bcbio-vc", ["bedtools", "cnvkit", "delly", "extract-sv-reads",
-                         "lumpy-sv", "manta", "mosdepth", "samtools",
+                         "lumpy-sv", "manta", "break-point-inspector", "mosdepth", "samtools",
                          "seq2c", "simple_sv_annotation", "svtools", "svtyper",
                          "r=3.4.1", "vawk"],
             disk={"files": 2.0})]

--- a/bcbio/provenance/programs.py
+++ b/bcbio/provenance/programs.py
@@ -36,7 +36,7 @@ _cl_progs = [{"cmd": "bamtofastq", "name": "biobambam",
              {"cmd": "featurecounts", "args": "-v", "stdout_flag": "featureCounts"}]
 _manifest_progs = ["bcbio-variation", "bioconductor-bubbletree", "cufflinks",
                    "cnvkit", "gatk4", "gatk-framework", "hisat2", "sailfish", "salmon",
-                   "grabix", "htseq", "lumpy-sv", "manta", "metasv", "mirdeep2", "oncofuse",
+                   "grabix", "htseq", "lumpy-sv", "manta", "break-point-inspector", "metasv", "mirdeep2", "oncofuse",
                    "picard", "phylowgs", "platypus-variant",
                    "rna-star", "rtg-tools", "sambamba", "samblaster", "scalpel",
                    "seqbuster", "snpeff", "vardict",


### PR DESCRIPTION
Hi Brad,

Adding Hartwig's BPI for Manta call filtering: https://github.com/hartwigmedical/hmftools/tree/master/break-point-inspector
Can be turned on with `tools_on: break-point-inspector`.

BPI significantly reduces the number of reported PASSed calls, 2-3 times in WGS samples that we experimented with, and we didn't spot any loss in sensitivity so far (though never actually benchmarked). Good to have it optional until we perform evaluation on a truth set, or Illumina guys consider adding it into Manta.

Needs this Bioconda PR to be accepted: https://github.com/bioconda/bioconda-recipes/pull/7061

Vlad