### PR TITLE
Add a prefix for the variant regions to avoid filename output clobbering

### DIFF
--- a/bcbio/pipeline/sample.py
+++ b/bcbio/pipeline/sample.py
@@ -199,7 +199,7 @@ def clean_inputs(data):
     """
     if not utils.get_in(data, ("config", "algorithm", "variant_regions_orig")):
         data["config"]["algorithm"]["variant_regions_orig"] = dd.get_variant_regions(data)
-    clean_vr = clean_file(dd.get_variant_regions(data), data)
+    clean_vr = clean_file(dd.get_variant_regions(data), data, prefix="cleaned-")
     merged_vr = merge_overlaps(clean_vr, data)
     data["config"]["algorithm"]["variant_regions"] = clean_vr
     data["config"]["algorithm"]["variant_regions_merged"] = merged_vr


### PR DESCRIPTION
@chapmanb Not sure if other operations depend on the name in particular, but this could avoid the filename output clobbering that may be happening when cwltool is running.  Here is a proposed PR if that's the case.