### PR TITLE
Fall back to bcftools if GATK4 is disabled when joining variants

### DIFF
--- a/bcbio/variation/vcfutils.py
+++ b/bcbio/variation/vcfutils.py
@@ -371,7 +371,7 @@ def concat_variant_files(orig_files, out_file, regions, ref_file, config):
     if out_file.endswith(".gz"):
         bgzip_and_index(out_file, config)
 
-      return out_file
+    return out_file
 
 def _run_concat_variant_files_gatk4(input_file_list, out_file, config):
     """Use GATK4 GatherVcfs for concatenation of scattered VCFs.

--- a/bcbio/variation/vcfutils.py
+++ b/bcbio/variation/vcfutils.py
@@ -368,8 +368,8 @@ def concat_variant_files(orig_files, out_file, regions, ref_file, config):
             else:
                 raise
 
-       if out_file.endswith(".gz"):
-           bgzip_and_index(out_file, config)
+    if out_file.endswith(".gz"):
+        bgzip_and_index(out_file, config)
 
       return out_file
 


### PR DESCRIPTION
It turns out that the GATK4 is called inconditionally when merging
VCFs, after the move from gatk-framework. Unfortunately, this breaks if
GATK4 has been disabled by the user, so this patch makes the function
fall back to the bcftools based variant.

Fixes issue #2257.