### PR TITLE
cnvkit diagram: Fix chrX display for male samples

### DIFF
--- a/bcbio/structural/cnvkit.py
+++ b/bcbio/structural/cnvkit.py
@@ -677,7 +677,7 @@ def _add_diagram_plot(out, data):
                    "-o", tx_out_file, cnr]
             gender = population.get_gender(data)
             if gender and gender.lower() == "male":
-                cmd += ["--male-reference"]
+                cmd += ["--sample-sex", gender]
             do.run(_prep_cmd(cmd, tx_out_file), "CNVkit diagram plot")
     return out_file
 


### PR DESCRIPTION
Per issue #2267 and following up on f008e6341d207867ec0a7d4ff3d75a27269f92ad, the `--male-reference` isn't needed here, but the `--sample-sex` option can still be useful, matching the `cnvkit.py call` usage.