### PR TITLE
Apply min_allele_fraction for Strelka2 and MuTect2 calls

### DIFF
--- a/bcbio/variation/germline.py
+++ b/bcbio/variation/germline.py
@@ -97,7 +97,7 @@ def _remove_prioritization(in_file, data):
     return out_file
 
 def _update_prioritization_filters(rec):
-    rec = _remove_filter(rec, "LowPriority")
+    rec = vcfutils.cyvcf_remove_filter(rec, "LowPriority")
     return _update_germline_filters(rec)
 
 def _extract_germline(in_file, data):
@@ -125,7 +125,7 @@ def _update_germline_filters(rec):
 
 def _add_somatic_filter(rec):
     if _is_somatic(rec):
-        return _add_filter(rec, "Somatic")
+        return vcfutils.cyvcf_add_filter(rec, "Somatic")
     return rec
 
 def _remove_germline_filter(rec, name):
@@ -135,10 +135,10 @@ def _remove_germline_filter(rec, name):
     """
     if _is_germline(rec):
         if rec.FILTER and name in rec.FILTER:
-            return _remove_filter(rec, name)
+            return vcfutils.cyvcf_remove_filter(rec, name)
     elif not _is_somatic(rec):
         if rec.FILTER and name in rec.FILTER:
-            return _remove_filter(rec, name)
+            return vcfutils.cyvcf_remove_filter(rec, name)
     return rec
 
 def _is_somatic(rec):
@@ -186,26 +186,3 @@ def _is_germline(rec):
         if str(status_flag).lower() in ["germline", "likelyloh", "strongloh", "afdiff", "deletion"]:
             return True
     return False
-
-def _add_filter(rec, name):
-    if rec.FILTER:
-        filters = rec.FILTER.split(";")
-    else:
-        filters = []
-    if name not in filters:
-        filters.append(name)
-        rec.FILTER = filters
-    return rec
-
-def _remove_filter(rec, name):
-    """Remove filter with the given name from VCF input.
-    """
-    if rec.FILTER:
-        filters = rec.FILTER.split(";")
-    else:
-        filters = []
-    new_filters = [x for x in filters if not str(x) == name]
-    if len(new_filters) == 0:
-        new_filters = ["PASS"]
-    rec.FILTER = new_filters
-    return rec

--- a/bcbio/variation/normalize.py
+++ b/bcbio/variation/normalize.py
@@ -77,21 +77,6 @@ def normalize(in_file, data, passonly=False, normalize_indels=True, split_bialle
             utils.symlink_plus(in_file, out_file)
     return vcfutils.bgzip_and_index(out_file, data["config"])
 
-def _find_existing_effects(in_file):
-    """Find effects values pre-annotated in VCF to remove.
-    """
-    ann_to_check = ["CSQ", "ANN"]
-    rec_iter = cyvcf2.VCF(in_file)
-    out = []
-    for a in ann_to_check:
-        try:
-            h = rec_iter.get_header_type(a)
-            out.append(a)
-        except KeyError:
-            pass
-    return out
-
-
 def _normalize(in_file, data, passonly=False, normalize_indels=True, split_biallelic=True,
                remove_oldeffects=False):
     """Convert multi-allelic variants into single allelic.
@@ -103,9 +88,9 @@ def _normalize(in_file, data, passonly=False, normalize_indels=True, split_biall
     """
     if remove_oldeffects:
         out_file = "%s-noeff-decompose%s" % utils.splitext_plus(in_file)
-        cur_effects = _find_existing_effects(in_file)
-        if cur_effects:
-            clean_effects_cmd = " | bcftools annotate -x %s " % (",".join(["INFO/%s" % x for x in cur_effects]))
+        old_effects = [a for a in ["CSQ", "ANN"] if a in cyvcf2.VCF(in_file)]
+        if old_effects:
+            clean_effects_cmd = " | bcftools annotate -x %s " % (",".join(["INFO/%s" % x for x in old_effects]))
         else:
             clean_effects_cmd = ""
     else:

--- a/bcbio/variation/strelka2.py
+++ b/bcbio/variation/strelka2.py
@@ -188,8 +188,9 @@ def _af_annotate_and_filter(paired, items, in_file, out_file):
                 else:  # germline?
                     alt_counts = rec.format('AD')[:,1:]  # AD=REF,ALT1,ALT2,...
                     dp = np.sum(rec.format('AD')[:,0:], axis=1)
-                assert np.all(dp > 0), rec
-                af = np.true_divide(alt_counts, dp)
+                with np.errstate(divide='ignore', invalid='ignore'):  # ignore division by zero and put AF=.0
+                    af = np.true_divide(alt_counts, dp)
+                    af[~np.isfinite(af)] = .0  # -inf inf NaN -> .0
                 rec.set_format('AF', af)
                 if np.any(af[tumor_index] < min_freq):
                     vcfutils.cyvcf_add_filter(rec, 'MinAF')

--- a/bcbio/variation/vcfutils.py
+++ b/bcbio/variation/vcfutils.py
@@ -653,3 +653,28 @@ def is_gvcf_file(in_file):
                 # platypue
                 if parts[4] == "N" and parts[6] == "REFCALL":
                     return True
+
+def cyvcf_add_filter(rec, name):
+    """Add a FILTER value to a cyvcf2 record
+    """
+    if rec.FILTER:
+        filters = rec.FILTER.split(";")
+    else:
+        filters = []
+    if name not in filters:
+        filters.append(name)
+        rec.FILTER = filters
+    return rec
+
+def cyvcf_remove_filter(rec, name):
+    """Remove filter with the given name from a cyvcf2 record
+    """
+    if rec.FILTER:
+        filters = rec.FILTER.split(";")
+    else:
+        filters = []
+    new_filters = [x for x in filters if not str(x) == name]
+    if len(new_filters) == 0:
+        new_filters = ["PASS"]
+    rec.FILTER = new_filters
+    return rec


### PR DESCRIPTION
Currently, `min_allele_fraction` is applied to VarDict, Freebayes, Varscan, and Scalpel, but not to Mutect and Strelka2 calls. In this PR, adding support for that for the latter callers.

For Strelka2, calculating and populating `FORMAT/AF` field, which is derived from existing `AD` (germline) or `*U` (somatic snps) or `TIR` (somatic indels) FORMAT fields that represent allelic depths.

Low-AF variants are soft-filtered by adding `MinAF` into `FILTER`. Let me know if it makes sense to rather hard-filter.

Also, I figured that's not really possible to pipe filtering from the existing variant calling commands, because we can't reliably know in advance the position of the tumor sample column in VCF, so need to have VCF file saved before filtering. But that doesn't seem to add any noticeable overhead.