### PR TITLE
Strelka2 and Mutect2 MinAF check: use np.all to check multiallelic

### DIFF
--- a/bcbio/variation/mutect2.py
+++ b/bcbio/variation/mutect2.py
@@ -142,7 +142,7 @@ def _af_filter(data, in_file, out_file):
             w = Writer(tx_out_file, vcf)
             tumor_index = vcf.samples.index(data['description'])
             for rec in vcf:
-                if rec.format('AF')[tumor_index] < min_freq:
+                if np.all(rec.format('AF')[tumor_index] < min_freq):
                     vcfutils.cyvcf_add_filter(rec, 'MinAF')
                 w.write_record(rec)
             w.close()

--- a/bcbio/variation/strelka2.py
+++ b/bcbio/variation/strelka2.py
@@ -192,7 +192,7 @@ def _af_annotate_and_filter(paired, items, in_file, out_file):
                     af = np.true_divide(alt_counts, dp)
                     af[~np.isfinite(af)] = .0  # -inf inf NaN -> .0
                 rec.set_format('AF', af)
-                if np.any(af[tumor_index] < min_freq):
+                if np.all(af[tumor_index] < min_freq):
                     vcfutils.cyvcf_add_filter(rec, 'MinAF')
                 w.write_record(rec)
             w.close()


### PR DESCRIPTION
Minor fix for the MinAF check. For multiallelic variants, we want to reject only those where all alleles are below the threshold.